### PR TITLE
PR: feature-timer-badge-view, Refactoring timer badge view to module

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,7 +8,7 @@ disabled_rules:
 - force_cast
 - no_fallthrough_only
 - multiple_closures_with_trailing_closure
-
+- large_tuple
 - function_body_length
 
 # Optional rule

--- a/timer.xcodeproj/project.pbxproj
+++ b/timer.xcodeproj/project.pbxproj
@@ -26,6 +26,9 @@
 		F303F281225CCE9D00A11FAF /* ProductivityViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F303F280225CCE9D00A11FAF /* ProductivityViewCoordinator.swift */; };
 		F303F283225CD51400A11FAF /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F303F282225CD51400A11FAF /* MainViewController.swift */; };
 		F303F285225CD53A00A11FAF /* MainViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F303F284225CD53A00A11FAF /* MainViewCoordinator.swift */; };
+		F334090022D0D8E2008661EC /* TimerBadgeCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F33408FF22D0D8E2008661EC /* TimerBadgeCollectionView.swift */; };
+		F334090522D3623F008661EC /* TimerBadgeAddCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F334090422D3623F008661EC /* TimerBadgeAddCollectionViewCell.swift */; };
+		F334090722D3A139008661EC /* TimerBadgeViewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F334090622D3A139008661EC /* TimerBadgeViewReactor.swift */; };
 		F33C6AB42291612E00FC461A /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = F33C6AB32291612E00FC461A /* Header.swift */; };
 		F33C6AB62291678300FC461A /* CALayer+border.swift in Sources */ = {isa = PBXBuildFile; fileRef = F33C6AB52291678300FC461A /* CALayer+border.swift */; };
 		F352034E227FCD0E00E05E2E /* CheckBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = F352034D227FCD0E00E05E2E /* CheckBox.swift */; };
@@ -36,7 +39,7 @@
 		F373CCD42265F995007ECCA0 /* TimeSetService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F373CCD32265F995007ECCA0 /* TimeSetService.swift */; };
 		F373CCD62265FA33007ECCA0 /* TMTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F373CCD52265FA33007ECCA0 /* TMTimer.swift */; };
 		F389657722759BAA0043E177 /* TimerSetServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F389657622759BAA0043E177 /* TimerSetServiceTest.swift */; };
-		F3925ACC2281CA96005CE9DD /* ProductivityTimerCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3925ACB2281CA96005CE9DD /* ProductivityTimerCollectionViewCell.swift */; };
+		F3925ACC2281CA96005CE9DD /* TimerBadgeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3925ACB2281CA96005CE9DD /* TimerBadgeCollectionViewCell.swift */; };
 		F3A1FACB229308D900CB4814 /* NanumSquareR.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F3A1FAC7229308D900CB4814 /* NanumSquareR.ttf */; };
 		F3A1FACC229308D900CB4814 /* NanumSquareL.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F3A1FAC8229308D900CB4814 /* NanumSquareL.ttf */; };
 		F3A1FACD229308D900CB4814 /* NanumSquareB.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F3A1FAC9229308D900CB4814 /* NanumSquareB.ttf */; };
@@ -51,7 +54,7 @@
 		F3C187542262052300B2C644 /* AppInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C187532262052300B2C644 /* AppInfoView.swift */; };
 		F3C18756226306EC00B2C644 /* CoordinatorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C18755226306EC00B2C644 /* CoordinatorProtocol.swift */; };
 		F3C18758226318DB00B2C644 /* AppService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C18757226318DB00B2C644 /* AppService.swift */; };
-		F3C2E7B9228318C500C69FF2 /* ProductivityTimerCollectionViewCellReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C2E7B8228318C500C69FF2 /* ProductivityTimerCollectionViewCellReactor.swift */; };
+		F3C2E7B9228318C500C69FF2 /* TimerBadgeCellReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3C2E7B8228318C500C69FF2 /* TimerBadgeCellReactor.swift */; };
 		F3D1F78C225CB6C1006DC162 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3D1F78B225CB6C1006DC162 /* AppDelegate.swift */; };
 		F3D1F793225CB6C2006DC162 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F3D1F792225CB6C2006DC162 /* Assets.xcassets */; };
 		F3D1F796225CB6C2006DC162 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F3D1F794225CB6C2006DC162 /* LaunchScreen.storyboard */; };
@@ -149,6 +152,9 @@
 		F303F280225CCE9D00A11FAF /* ProductivityViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductivityViewCoordinator.swift; sourceTree = "<group>"; };
 		F303F282225CD51400A11FAF /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		F303F284225CD53A00A11FAF /* MainViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewCoordinator.swift; sourceTree = "<group>"; };
+		F33408FF22D0D8E2008661EC /* TimerBadgeCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerBadgeCollectionView.swift; sourceTree = "<group>"; };
+		F334090422D3623F008661EC /* TimerBadgeAddCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerBadgeAddCollectionViewCell.swift; sourceTree = "<group>"; };
+		F334090622D3A139008661EC /* TimerBadgeViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerBadgeViewReactor.swift; sourceTree = "<group>"; };
 		F33C6AB32291612E00FC461A /* Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
 		F33C6AB52291678300FC461A /* CALayer+border.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+border.swift"; sourceTree = "<group>"; };
 		F352034D227FCD0E00E05E2E /* CheckBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckBox.swift; sourceTree = "<group>"; };
@@ -161,7 +167,7 @@
 		F389657422759BAA0043E177 /* test.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = test.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F389657622759BAA0043E177 /* TimerSetServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerSetServiceTest.swift; sourceTree = "<group>"; };
 		F389657822759BAA0043E177 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		F3925ACB2281CA96005CE9DD /* ProductivityTimerCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductivityTimerCollectionViewCell.swift; sourceTree = "<group>"; };
+		F3925ACB2281CA96005CE9DD /* TimerBadgeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerBadgeCollectionViewCell.swift; sourceTree = "<group>"; };
 		F3A1FAC7229308D900CB4814 /* NanumSquareR.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = NanumSquareR.ttf; sourceTree = "<group>"; };
 		F3A1FAC8229308D900CB4814 /* NanumSquareL.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = NanumSquareL.ttf; sourceTree = "<group>"; };
 		F3A1FAC9229308D900CB4814 /* NanumSquareB.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = NanumSquareB.ttf; sourceTree = "<group>"; };
@@ -176,7 +182,7 @@
 		F3C187532262052300B2C644 /* AppInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoView.swift; sourceTree = "<group>"; };
 		F3C18755226306EC00B2C644 /* CoordinatorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorProtocol.swift; sourceTree = "<group>"; };
 		F3C18757226318DB00B2C644 /* AppService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppService.swift; sourceTree = "<group>"; };
-		F3C2E7B8228318C500C69FF2 /* ProductivityTimerCollectionViewCellReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductivityTimerCollectionViewCellReactor.swift; sourceTree = "<group>"; };
+		F3C2E7B8228318C500C69FF2 /* TimerBadgeCellReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerBadgeCellReactor.swift; sourceTree = "<group>"; };
 		F3D1F788225CB6C1006DC162 /* timer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = timer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F3D1F78B225CB6C1006DC162 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F3D1F792225CB6C2006DC162 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -290,6 +296,26 @@
 			path = Fonts;
 			sourceTree = "<group>";
 		};
+		F33408FE22D0D8BC008661EC /* TimerBadgeView */ = {
+			isa = PBXGroup;
+			children = (
+				F334090322D0D9B5008661EC /* Cell */,
+				F33408FF22D0D8E2008661EC /* TimerBadgeCollectionView.swift */,
+				F334090622D3A139008661EC /* TimerBadgeViewReactor.swift */,
+			);
+			path = TimerBadgeView;
+			sourceTree = "<group>";
+		};
+		F334090322D0D9B5008661EC /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				F334090422D3623F008661EC /* TimerBadgeAddCollectionViewCell.swift */,
+				F3925ACB2281CA96005CE9DD /* TimerBadgeCollectionViewCell.swift */,
+				F3C2E7B8228318C500C69FF2 /* TimerBadgeCellReactor.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
 		F3735C9222CFA78100DC247C /* Support */ = {
 			isa = PBXGroup;
 			children = (
@@ -354,7 +380,6 @@
 		F3735C9822CFA88700DC247C /* Productivity */ = {
 			isa = PBXGroup;
 			children = (
-				F3F65D7122CFAB52009C667B /* Cell */,
 				F303F27A225CCE1600A11FAF /* ProductivityViewController.swift */,
 				F303F27C225CCE2400A11FAF /* ProductivityView.swift */,
 				F303F27E225CCE7100A11FAF /* ProductivityViewReactor.swift */,
@@ -520,6 +545,7 @@
 		F3D49922227F272600AC4B2B /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				F33408FE22D0D8BC008661EC /* TimerBadgeView */,
 				F3D49923227F273E00AC4B2B /* KeyPad.swift */,
 				F352034D227FCD0E00E05E2E /* CheckBox.swift */,
 				F33C6AB32291612E00FC461A /* Header.swift */,
@@ -536,15 +562,6 @@
 				F3F342B5226751A300A226C0 /* Info.plist */,
 			);
 			path = widget;
-			sourceTree = "<group>";
-		};
-		F3F65D7122CFAB52009C667B /* Cell */ = {
-			isa = PBXGroup;
-			children = (
-				F3925ACB2281CA96005CE9DD /* ProductivityTimerCollectionViewCell.swift */,
-				F3C2E7B8228318C500C69FF2 /* ProductivityTimerCollectionViewCellReactor.swift */,
-			);
-			path = Cell;
 			sourceTree = "<group>";
 		};
 		F3F65D7222CFAB7F009C667B /* Base */ = {
@@ -863,11 +880,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F3925ACC2281CA96005CE9DD /* ProductivityTimerCollectionViewCell.swift in Sources */,
+				F3925ACC2281CA96005CE9DD /* TimerBadgeCollectionViewCell.swift in Sources */,
 				F3AEA730228B1D7500D563E0 /* TabBarInteractor.swift in Sources */,
 				F3D1F7BD225CC357006DC162 /* UIViewController+child.swift in Sources */,
 				F303F273225CCB7500A11FAF /* SettingViewCoordinator.swift in Sources */,
-				F3C2E7B9228318C500C69FF2 /* ProductivityTimerCollectionViewCellReactor.swift in Sources */,
+				F3C2E7B9228318C500C69FF2 /* TimerBadgeCellReactor.swift in Sources */,
 				F373CCD62265FA33007ECCA0 /* TMTimer.swift in Sources */,
 				F3C18752226204F700B2C644 /* AppInfoCoordinator.swift in Sources */,
 				F3F65D7422CFAC77009C667B /* SharedTimeSetViewController.swift in Sources */,
@@ -878,6 +895,7 @@
 				F3AEA72D228B1A6300D563E0 /* TabBarAnimator.swift in Sources */,
 				F3C18756226306EC00B2C644 /* CoordinatorProtocol.swift in Sources */,
 				F373CCD42265F995007ECCA0 /* TimeSetService.swift in Sources */,
+				F334090522D3623F008661EC /* TimerBadgeAddCollectionViewCell.swift in Sources */,
 				F3F800B6226A0D0F003D1D88 /* String+localized.swift in Sources */,
 				F3D1F7BE225CC357006DC162 /* UIView+autolayout.swift in Sources */,
 				F3D1F7AA225CC1E8006DC162 /* ServiceProvider.swift in Sources */,
@@ -911,9 +929,11 @@
 				F3E4383E226E0FEB00FA1246 /* EventStreamModelProtocol.swift in Sources */,
 				F3D1F7BC225CC357006DC162 /* String+regex.swift in Sources */,
 				F303F285225CD53A00A11FAF /* MainViewCoordinator.swift in Sources */,
+				F334090022D0D8E2008661EC /* TimerBadgeCollectionView.swift in Sources */,
 				F3D1F7B2225CC2A9006DC162 /* BaseViewController.swift in Sources */,
 				F303F27B225CCE1600A11FAF /* ProductivityViewController.swift in Sources */,
 				F3D49924227F273E00AC4B2B /* KeyPad.swift in Sources */,
+				F334090722D3A139008661EC /* TimerBadgeViewReactor.swift in Sources */,
 				F37041CB226B81B00012EA16 /* TimeSet.swift in Sources */,
 				F37041C9226B65550012EA16 /* TimerInfo.swift in Sources */,
 				F3D1F7BB225CC357006DC162 /* Primitive+adjust.swift in Sources */,

--- a/timer/Common/Functions.swift
+++ b/timer/Common/Functions.swift
@@ -24,6 +24,16 @@ func getDate(format: String, date: String) -> Date? {
     return formatter.date(from: date)
 }
 
+func getTime(interval: TimeInterval) -> (Int, Int, Int) {
+    let time = Int(interval)
+    
+    let seconds = time % 60
+    let minutes = (time / 60) % 60
+    let hours = time / 3600
+    
+    return (hours, minutes, seconds)
+}
+
 func roundCorners(view: UIView, byRoundingCorners: UIRectCorner, cornerRadius: CGFloat) {
     let maskLayer = CAShapeLayer()
     maskLayer.frame = view.bounds

--- a/timer/Model/TimerInfo.swift
+++ b/timer/Model/TimerInfo.swift
@@ -25,18 +25,10 @@ class TimerInfo: Codable {
     var state: State // Current state of the timer
     
     // MARK: constructor
-    init(title: String, currentTime: TimeInterval, endTime: TimeInterval, state: State) {
+    init(title: String, currentTime: TimeInterval = 0, endTime: TimeInterval = 0, state: State = .stop) {
         self.title = title
         self.currentTime = currentTime
         self.endTime = endTime
         self.state = state
-    }
-    
-    convenience init(title: String, endTime: TimeInterval) {
-        self.init(title: title, currentTime: 0, endTime: endTime, state: .stop)
-    }
-    
-    convenience init(title: String) {
-        self.init(title: title, currentTime: 0, endTime: 0, state: .stop)
     }
 }

--- a/timer/Module/Common/TimerBadgeView/Cell/TimerBadgeAddCollectionViewCell.swift
+++ b/timer/Module/Common/TimerBadgeView/Cell/TimerBadgeAddCollectionViewCell.swift
@@ -1,0 +1,68 @@
+//
+//  TimerBadgeAddCollectionViewCell.swift
+//  timer
+//
+//  Created by JSilver on 2019/07/08.
+//  Copyright © 2019 Jeong Jin Eun. All rights reserved.
+//
+
+import UIKit
+import RxSwift
+
+class TimerBadgeAddCollectionViewCell: UICollectionViewCell {
+    static let ReuseableIdentifier = "TimerBadgeAddCollectionViewCell"
+    
+    // MARK: - view properties
+    let addLabel: UILabel = {
+        let view = UILabel()
+        view.text = "+"
+        view.textColor = Constants.Color.white
+        view.font = Constants.Font.ExtraBold.withSize(12.adjust())
+        view.textAlignment = .center
+        return view
+    }()
+    
+    private lazy var containerView: UIView = { [unowned self] in
+        let view = UIView()
+        view.backgroundColor = Constants.Color.black
+        
+        // Set constarint of subviews
+        view.addAutolayoutSubview(self.addLabel)
+        addLabel.snp.makeConstraints { make in
+            make.edges.equalTo(UIEdgeInsets(top: 5.adjust(), left: 6.adjust(), bottom: 5.adjust(), right: 6.adjust()))
+        }
+        
+        return view
+    }()
+    
+    // MARK: - properties
+    var disposeBag: DisposeBag = DisposeBag()
+    
+    // MARK: - constructor
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+        
+        contentView.addAutolayoutSubview(containerView)
+
+        containerView.snp.makeConstraints { make in
+            make.leading.equalToSuperview()
+            make.trailing.equalToSuperview()
+            make.centerY.equalToSuperview()
+            make.height.equalTo(24.adjust())
+        }
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - lifecycle
+    override func draw(_ rect: CGRect) {
+        containerView.layer.cornerRadius = containerView.bounds.height / 2
+    }
+}

--- a/timer/Module/Common/TimerBadgeView/Cell/TimerBadgeCellReactor.swift
+++ b/timer/Module/Common/TimerBadgeView/Cell/TimerBadgeCellReactor.swift
@@ -1,5 +1,5 @@
 //
-//  ProductivityTimerCollectionViewCellReactor.swift
+//  TimerBadgeCollectionViewReactor.swift
 //  timer
 //
 //  Created by JSilver on 08/05/2019.
@@ -9,44 +9,46 @@
 import RxSwift
 import ReactorKit
 
-class ProductivityTimerCollectionViewCellReactor: Reactor {
+class TimerBadgeCellReactor: Reactor {
     enum Action {
         case updateTime(TimeInterval)
         case select(Bool)
+        
+        case setoOtionVisible(Bool)
     }
     
     enum Mutation {
         case setTime(TimeInterval)
         case setSelected(Bool)
+        case setIsOptionVisible(Bool)
     }
     
     struct State {
-        var time: TimeInterval
         let index: Int
-        var selected: Bool
+        var time: TimeInterval
+        var isSelected: Bool
+        var isOptionVisible: Bool
     }
     
     // MARK: - properties
     var initialState: State
-    private var info: TimerInfo
+    private var timerInfo: TimerInfo
     
-    init(info: TimerInfo, index: Int, selected: Bool) {
-        self.info = info
-        self.initialState = State(time: info.endTime, index: index, selected: selected)
-    }
-    
-    convenience init(info: TimerInfo, index: Int) {
-        self.init(info: info, index: index, selected: false)
+    init(info: TimerInfo, index: Int, isSelected: Bool = false, isOptionVisible: Bool = true) {
+        self.timerInfo = info
+        self.initialState = State(index: index, time: info.endTime, isSelected: isSelected, isOptionVisible: isOptionVisible)
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case let .updateTime(time):
             // Update timer info
-            info.endTime = time
+            timerInfo.endTime = time
             return .just(.setTime(time))
         case let .select(isSelected):
             return .just(.setSelected(isSelected))
+        case let .setoOtionVisible(isOptionVisible):
+            return .just(.setIsOptionVisible(isOptionVisible))
         }
     }
     
@@ -57,7 +59,10 @@ class ProductivityTimerCollectionViewCellReactor: Reactor {
             state.time = time
             return state
         case let .setSelected(isSelected):
-            state.selected = isSelected
+            state.isSelected = isSelected
+            return state
+        case let .setIsOptionVisible(isOptionVisible):
+            state.isOptionVisible = isOptionVisible
             return state
         }
     }

--- a/timer/Module/Common/TimerBadgeView/TimerBadgeCollectionView.swift
+++ b/timer/Module/Common/TimerBadgeView/TimerBadgeCollectionView.swift
@@ -1,0 +1,283 @@
+//
+//  TimerBadgeCollectionView.swift
+//  timer
+//
+//  Created by JSilver on 2019/07/06.
+//  Copyright © 2019 Jeong Jin Eun. All rights reserved.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+import RxDataSources
+import ReactorKit
+
+protocol ReactiveDataSource: View {
+    associatedtype SectionType: SectionModelType
+}
+
+typealias TimerBadgeSectionModel = SectionModel<Void, TimerBadgeCellType>
+
+class TimerBadgeCollectionView: UICollectionView, ReactiveDataSource {
+    typealias SectionType = TimerBadgeSectionModel
+    
+    // MARK: - constants
+    static let centerAnchor = CGPoint(x: -1, y: -1)
+    
+    // MARK: - properties
+    private lazy var _dataSource = RxCollectionViewSectionedReloadDataSource<SectionType>(configureCell: { (dataSource, collectionView, indexPath, cellType) -> UICollectionViewCell in
+        switch cellType {
+        case let .regular(reactor):
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TimerBadgeCollectionViewCell.ReuseableIdentifier, for: indexPath) as! TimerBadgeCollectionViewCell
+            // Send action into reactor for initialize state
+            reactor.action.onNext(.setoOtionVisible(self.isOptionButtonVisible))
+            cell.reactor = reactor
+            
+            return cell
+        case .add:
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TimerBadgeAddCollectionViewCell.ReuseableIdentifier, for: indexPath)
+            return cell
+        }
+    })
+    
+    // Timer badge option button visible/hidden property
+    var isOptionButtonVisible = true
+    
+    // Timer badge extra cell config property
+    fileprivate var extraCell: TimerBadgeCellType?
+    fileprivate var shouldShowExtraCell: ([TimerInfo], TimerBadgeCellType) -> Bool = { _, _ in
+        return true
+    }
+    
+    var anchorPoint = CGPoint(x: 0, y: 0)
+    var isAutoScroll = true
+    
+    override var intrinsicContentSize: CGSize {
+        return CGSize(width: 0, height: 60.adjust())
+    }
+    
+    var disposeBag = DisposeBag()
+    
+    // MARK: - constructor
+    override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
+        super.init(frame: frame, collectionViewLayout: layout)
+        self.reactor = TimerBadgeViewReactor()
+    }
+    
+    convenience init(frame: CGRect) {
+        // Create collection view flow layout
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        // layout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize // self-sizing cell
+        layout.itemSize = CGSize(width: 75.adjust(), height: 60.adjust())
+        layout.minimumInteritemSpacing = 10.adjust()
+
+        self.init(frame: frame, collectionViewLayout: layout)
+        backgroundColor = Constants.Color.clear
+        showsHorizontalScrollIndicator = false
+        
+        // Register timer badge collection view reusable cell
+        register(TimerBadgeCollectionViewCell.self, forCellWithReuseIdentifier: TimerBadgeCollectionViewCell.ReuseableIdentifier)
+        register(TimerBadgeAddCollectionViewCell.self, forCellWithReuseIdentifier: TimerBadgeAddCollectionViewCell.ReuseableIdentifier)
+        
+        // Bind common view events
+        bind()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - bind
+    func bind() {
+        rx.setDelegate(self).disposed(by: disposeBag)
+    }
+    
+    func bind(reactor: TimerBadgeViewReactor) {
+        // MARK: action
+        rx.itemSelected
+            .map { Reactor.Action.selectBadge($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        // MARK: state
+        reactor.state
+            .map { $0.sections }
+            .bind(to: rx.items(dataSource: _dataSource))
+            .disposed(by: disposeBag)
+    
+        reactor.state
+            .map { $0.selectedIndexPath }
+            .distinctUntilChanged()
+            .filter { _ in self.isAutoScroll }
+            .debounce(0.1, scheduler: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] indexPath in self?.moveToSelectedBadge(indexPath: indexPath) })
+            .disposed(by: disposeBag)
+    }
+    
+    /**
+     Animate that move cell to anchor point
+     
+     - parameters:
+        - indexPath: Index path of selected cell
+     */
+    private func moveToSelectedBadge(indexPath: IndexPath?) {
+        guard let indexPath = indexPath,
+            let layout = self.collectionViewLayout as? UICollectionViewFlowLayout else { return }
+        
+        let cellOffset: CGFloat // Current cell offset in collection view
+        let diff: CGFloat // Deference about between cell offset and anchor point
+        
+        let index = CGFloat(indexPath.row)
+        switch layout.scrollDirection {
+        case .horizontal:
+            // Horizontal scroll
+            cellOffset = index * layout.itemSize.width + index * layout.minimumInteritemSpacing
+            if self.anchorPoint == TimerBadgeCollectionView.centerAnchor {
+                diff = self.bounds.width / 2 - layout.itemSize.width / 2
+            } else {
+                diff = self.anchorPoint.x
+            }
+        case .vertical:
+            // Vertical scroll
+            cellOffset = index * layout.itemSize.height + index * layout.minimumLineSpacing
+            if self.anchorPoint == TimerBadgeCollectionView.centerAnchor {
+                diff = self.bounds.height / 2 - layout.itemSize.height / 2
+            } else {
+                diff = self.anchorPoint.y
+            }
+        @unknown default:
+            fatalError()
+        }
+        
+        // Animate scroll to anchor point
+        UIView.animate(withDuration: 1) {
+            self.setContentOffset(CGPoint(x: cellOffset - diff, y: 0), animated: true)
+        }
+    }
+    
+    // MARK: - public method
+    // Set timer badge extra cell config
+    func setExtraCell(_ extraCell: TimerBadgeCellType, shouldShowExtraCell: (([TimerInfo], TimerBadgeCellType) -> Bool)?) {
+        self.extraCell = extraCell
+        if let shouldShowExtraCell = shouldShowExtraCell {
+            self.shouldShowExtraCell = shouldShowExtraCell
+        }
+    }
+}
+
+extension TimerBadgeCollectionView: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        // Ignore if display cell isn't first or last
+        guard indexPath.row == 0 || indexPath.row == collectionView.numberOfItems(inSection: 0) - 1 else { return }
+        let isFirst = indexPath.row == 0
+        
+        // Get content inset
+        let inset = calcInsetOfCollectionView(collectionView, cell: cell, anchorPoint: anchorPoint, isFirst: isFirst)
+        
+        // Set content inset to align center cell based on anchor point
+        var contentInset = collectionView.contentInset
+        if isFirst {
+            contentInset.left = inset
+        } else {
+            contentInset.right = inset
+        }
+        collectionView.contentInset = contentInset
+    }
+    
+    private func calcInsetOfCollectionView(_ collectionView: UICollectionView, cell: UICollectionViewCell, anchorPoint: CGPoint, isFirst: Bool) -> CGFloat {
+        guard let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout else { return 0 }
+        
+        switch layout.scrollDirection {
+        case .horizontal:
+            // Horizontal scroll
+            if anchorPoint == TimerBadgeCollectionView.centerAnchor {
+                return collectionView.bounds.width / 2 - cell.bounds.width / 2
+            } else {
+                return isFirst ? anchorPoint.x : collectionView.bounds.width - (cell.bounds.width + anchorPoint.x)
+            }
+        case .vertical:
+            // Vertical scroll
+            if anchorPoint == TimerBadgeCollectionView.centerAnchor {
+                return collectionView.bounds.height / 2 - cell.bounds.height / 2
+            } else {
+                return isFirst ? anchorPoint.y : collectionView.bounds.height - (cell.bounds.height + anchorPoint.y)
+            }
+        @unknown default:
+            fatalError()
+        }
+    }
+}
+
+extension TimerBadgeCollectionView: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        guard let layout = collectionViewLayout as? UICollectionViewFlowLayout else { return .zero }
+        guard let reactor = reactor else { return .zero }
+
+        let cellType = reactor.currentState.sections[0].items[indexPath.row]
+        switch cellType {
+        case .add:
+            var size = layout.itemSize
+            size.width = 24.adjust()
+            return size
+        default:
+            return layout.itemSize
+        }
+    }
+}
+
+// MARK: - Rx extension
+// TODO: Check memory leak
+extension Reactive where Base: TimerBadgeCollectionView {
+    var items: Binder<[TimerInfo]> {
+        return Binder(base.self) { _, timers in
+            Observable.just(timers)
+                .map {
+                    if let extraCell = self.base.extraCell, self.base.shouldShowExtraCell(timers, extraCell) {
+                        return Base.Reactor.Action.updateTimers($0, extraCell)
+                    }
+                    return Base.Reactor.Action.updateTimers($0, nil)
+                }
+                .bind(to: self.base.reactor!.action)
+                .disposed(by: self.base.disposeBag)
+        }
+    }
+    
+    var timer: Binder<TimeInterval> {
+        return Binder(base.self) { _, timeInterval in
+            Observable.just(timeInterval)
+                .map { Base.Reactor.Action.updateTimer($0) }
+                .bind(to: self.base.reactor!.action)
+                .disposed(by: self.base.disposeBag)
+        }
+    }
+    
+    var badgeSelected: ControlEvent<(IndexPath, TimerBadgeCellType)> {
+        let source = delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:didSelectItemAt:)))
+            .map { a -> (IndexPath, TimerBadgeCellType) in
+                let indexPath = a[1] as! IndexPath
+                let cellType = self.base.reactor!.currentState.sections[0].items[indexPath.row]
+                
+                return (a[1] as! IndexPath, cellType)
+        }
+        
+        return ControlEvent(events: source)
+    }
+}
+
+// Timer badge cell type
+enum TimerBadgeCellType {
+    case regular(TimerBadgeCellReactor)
+    case add
+    // Define here, if need to add any extra cell type
+    
+    // Get cell item
+    var item: TimerBadgeCellReactor? {
+        switch self {
+        case let .regular(reactor):
+            return reactor
+        default:
+            return nil
+        }
+    }
+}

--- a/timer/Module/Common/TimerBadgeView/TimerBadgeViewReactor.swift
+++ b/timer/Module/Common/TimerBadgeView/TimerBadgeViewReactor.swift
@@ -1,0 +1,81 @@
+//
+//  TimerBadgeViewReactor.swift
+//  timer
+//
+//  Created by JSilver on 2019/07/09.
+//  Copyright © 2019 Jeong Jin Eun. All rights reserved.
+//
+
+import RxSwift
+import ReactorKit
+
+class TimerBadgeViewReactor: Reactor {
+    enum Action {
+        case updateTimers([TimerInfo], TimerBadgeCellType?)
+        case updateTimer(TimeInterval)
+        case selectBadge(IndexPath)
+    }
+    
+    enum Mutation {
+        case setSections([TimerBadgeSectionModel])
+        case setSelectedIndexPath(IndexPath)
+        case updateTimer(TimeInterval, at: IndexPath)
+    }
+    
+    struct State {
+        var sections: [TimerBadgeSectionModel]
+        var selectedIndexPath: IndexPath?
+    }
+    
+    // MARK: - properties
+    var initialState: State
+    
+    init() {
+        self.initialState = State(sections: [TimerBadgeSectionModel(model: Void(), items: [])], selectedIndexPath: nil)
+    }
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case let .updateTimers(timers, extraCell):
+            var items = timers.enumerated().map { index, info in
+                TimerBadgeCellType.regular(TimerBadgeCellReactor(info: info, index: index + 1))
+            }
+            
+            if let extraCell = extraCell {
+                items.append(extraCell)
+            }
+            
+            let setSections = Observable.just(Mutation.setSections([TimerBadgeSectionModel(model: Void(), items: items)]))
+            let setSelectedIndexPath = currentState.selectedIndexPath == nil ?
+                Observable.just(Mutation.setSelectedIndexPath(IndexPath(row: 0, section: 0))) :
+                Observable.just(Mutation.setSelectedIndexPath(IndexPath(row: timers.count - 1, section: 0)))
+    
+            return .concat(setSections, setSelectedIndexPath)
+        case let .updateTimer(timeInterval):
+            guard let indexPath = currentState.selectedIndexPath else { return .empty() }
+            return .just(.updateTimer(timeInterval, at: indexPath))
+        case let .selectBadge(indexPath):
+            return .just(.setSelectedIndexPath(indexPath))
+        }
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        var state = state
+        switch mutation {
+        case let .setSections(sections):
+            state.sections = sections
+            return state
+        case let .setSelectedIndexPath(indexPath):
+            if let previousIndexPath = state.selectedIndexPath {
+                state.sections[0].items[previousIndexPath.row].item?.action.onNext(.select(false))
+            }
+            state.sections[0].items[indexPath.row].item?.action.onNext(.select(true))
+            
+            state.selectedIndexPath = indexPath
+            return state
+        case let .updateTimer(timeInterval, at: indexPath):
+            state.sections[0].items[indexPath.row].item?.action.onNext(.updateTime(timeInterval))
+            return state
+        }
+    }
+}

--- a/timer/Module/Main/Productivity/ProductivityView.swift
+++ b/timer/Module/Main/Productivity/ProductivityView.swift
@@ -234,16 +234,8 @@ class ProductivityView: UIView {
         return view
     }()
     
-    let timerCollectionView: UICollectionView = {
-        let layout = UICollectionViewFlowLayout()
-        layout.scrollDirection = .horizontal
-//        layout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize // self-sizing cell
-        layout.itemSize = CGSize(width: 75.adjust(), height: 60.adjust())
-        layout.minimumInteritemSpacing = 10.adjust()
-        
-        let view = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        view.backgroundColor = Constants.Color.clear
-        view.showsHorizontalScrollIndicator = false
+    let timerBadgeCollectionView: TimerBadgeCollectionView = {
+        let view = TimerBadgeCollectionView(frame: .zero)
         return view
     }()
     
@@ -251,7 +243,7 @@ class ProductivityView: UIView {
         let view = UIView()
         
         // Set constraint of subviews
-        view.addAutolayoutSubviews([self.timerInputView, self.timerInfoStackView, self.keyPadView, self.timeButtonStackView, self.timerCollectionView])
+        view.addAutolayoutSubviews([self.timerInputView, self.timerInfoStackView, self.keyPadView, self.timeButtonStackView, self.timerBadgeCollectionView])
         timerInputView.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(43.5.adjust())
             make.centerX.equalToSuperview()
@@ -276,11 +268,10 @@ class ProductivityView: UIView {
             make.width.equalTo(258.adjust())
         }
         
-        timerCollectionView.snp.makeConstraints { make in
+        timerBadgeCollectionView.snp.makeConstraints { make in
             make.top.equalTo(timeButtonStackView.snp.bottom)
             make.leading.equalToSuperview()
             make.trailing.equalToSuperview()
-            make.height.equalTo(60.adjust())
         }
         
         return view


### PR DESCRIPTION
# Change log

- Update swift lint
  - Disable rule `large_tuple`
- Remove useless constructor and add default parameters in `TimerInfo`
- Refactoring the timer badge view to module

# Description

Refactoring timer badge collection view in `ProductivityView` to separated view module `TimerBadgeView`
Update swift lint option and `TimerInfo` constructor etc... 