### PR TITLE
PR: feature-default-time-set-title, fix not saved time set's default title

### DIFF
--- a/timer/Source/Module/OpenSourceLicense/OpenSourceLicenseViewController.swift
+++ b/timer/Source/Module/OpenSourceLicense/OpenSourceLicenseViewController.swift
@@ -68,7 +68,6 @@ class OpenSourceLicenseViewController: BaseHeaderViewController, View {
             .map { $0! }
             .map { $0.data(using: .utf8) }
             .map { [weak self] in self?.getLicenseAttributedText(data: $0!) }
-//            .map { [weak self] in self?.getLicenseAttributedText($0) }
             .bind(to: openSourceTextView.rx.attributedText)
             .disposed(by: disposeBag)
     }
@@ -86,20 +85,6 @@ class OpenSourceLicenseViewController: BaseHeaderViewController, View {
     }
     
     // MARK: - state method
-    /// Get license attributed text from string
-    private func getLicenseAttributedText(_ text: String) -> NSAttributedString {
-        // Create paragraph style
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineSpacing = 12.adjust()
-        
-        // Set attributed string
-        return NSAttributedString(string: text, attributes: [
-            .font: Constants.Font.Regular.withSize(15.adjust()),
-            .foregroundColor: Constants.Color.codGray,
-            .paragraphStyle: paragraphStyle
-        ])
-    }
-    
     /// Get license attributed text from data
     private func getLicenseAttributedText(data: Data) -> NSAttributedString? {
         return try? NSAttributedString(data: data,

--- a/timer/Source/Module/Setting/SettingViewController.swift
+++ b/timer/Source/Module/Setting/SettingViewController.swift
@@ -54,12 +54,10 @@ class SettingViewController: BaseHeaderViewController, View {
     // MARK: - bind
     override func bind() {
         super.bind()
-        Logger.debug()
         settingTableView.rx.setDelegate(self).disposed(by: disposeBag)
     }
     
     func bind(reactor: SettingViewReactor) {
-        Logger.debug()
         // MARK: action
         rx.viewWillAppear
             .map { Reactor.Action.refresh }
@@ -90,11 +88,6 @@ class SettingViewController: BaseHeaderViewController, View {
         default:
             break
         }
-    }
-    
-    /// Handle setting menu selected
-    private func menuSelectd(indexPath: IndexPath) {
-        
     }
     
     deinit {

--- a/timer/Source/Module/TeamInfo/TeamInfoViewController.swift
+++ b/timer/Source/Module/TeamInfo/TeamInfoViewController.swift
@@ -45,7 +45,6 @@ class TeamInfoViewController: BaseHeaderViewController, View {
 	// MARK: - bind
     override func bind() {
         super.bind()
-        
         scrollView.rx.setDelegate(self).disposed(by: disposeBag)
     }
     

--- a/timer/Source/Module/TimeSetProcess/TimeSetProcessViewController.swift
+++ b/timer/Source/Module/TimeSetProcess/TimeSetProcessViewController.swift
@@ -512,8 +512,10 @@ class TimeSetProcessViewController: BaseHeaderViewController, View {
             timeSetAlert = nil
 
             // Present end view
-            guard let viewController = coordinator.present(for: .timeSetEnd(history)) as? TimeSetEndViewController else { return }
-            bind(end: viewController)
+            if history.endState == .normal {
+                guard let viewController = coordinator.present(for: .timeSetEnd(history)) as? TimeSetEndViewController else { return }
+                bind(end: viewController)
+            }
             
         default:
             break


### PR DESCRIPTION
# Change log
- Create action and state of time set edit view reactor to present
- Fix wrong present logic when time set end

# Description
## `shouldStart`, `shouldSave` is `State`?
I think too. It's also not natural. but there is a difference in interpretation. even if it force specific processes, but it still depends on `view` that how to represent elements.