### PR TITLE
PR: feature-toast, Create common toast and apply

### DIFF
--- a/timer.xcodeproj/project.pbxproj
+++ b/timer.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		F303F281225CCE9D00A11FAF /* ProductivityViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F303F280225CCE9D00A11FAF /* ProductivityViewCoordinator.swift */; };
 		F303F283225CD51400A11FAF /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F303F282225CD51400A11FAF /* MainViewController.swift */; };
 		F303F285225CD53A00A11FAF /* MainViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F303F284225CD53A00A11FAF /* MainViewCoordinator.swift */; };
+		F306022A2379812300A9C866 /* MainViewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30602292379812300A9C866 /* MainViewReactor.swift */; };
 		F3060F92230D19FE002A2E0E /* TimeSetEndView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3060F91230D19FE002A2E0E /* TimeSetEndView.swift */; };
 		F3060F95230E9B12002A2E0E /* TimeSetEndViewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3060F94230E9B12002A2E0E /* TimeSetEndViewReactor.swift */; };
 		F309F97922E9883100C280A0 /* TimerOptionViewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F309F97522E9883100C280A0 /* TimerOptionViewReactor.swift */; };
@@ -243,6 +244,7 @@
 		F303F280225CCE9D00A11FAF /* ProductivityViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductivityViewCoordinator.swift; sourceTree = "<group>"; };
 		F303F282225CD51400A11FAF /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		F303F284225CD53A00A11FAF /* MainViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewCoordinator.swift; sourceTree = "<group>"; };
+		F30602292379812300A9C866 /* MainViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewReactor.swift; sourceTree = "<group>"; };
 		F3060F91230D19FE002A2E0E /* TimeSetEndView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSetEndView.swift; sourceTree = "<group>"; };
 		F3060F94230E9B12002A2E0E /* TimeSetEndViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSetEndViewReactor.swift; sourceTree = "<group>"; };
 		F309F97522E9883100C280A0 /* TimerOptionViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerOptionViewReactor.swift; sourceTree = "<group>"; };
@@ -642,6 +644,7 @@
 				F302609022EEB89600E3E431 /* TMTabBarItem.swift */,
 				F302608E22EEAFC300E3E431 /* TMTabBar.swift */,
 				F303F282225CD51400A11FAF /* MainViewController.swift */,
+				F30602292379812300A9C866 /* MainViewReactor.swift */,
 				F303F284225CD53A00A11FAF /* MainViewCoordinator.swift */,
 				F3AEA72F228B1D7500D563E0 /* TabBarInteractor.swift */,
 				F3AEA72C228B1A6300D563E0 /* TabBarAnimator.swift */,
@@ -1523,6 +1526,7 @@
 				F38702B822F970E80099241C /* TimeSetDetailViewReactor.swift in Sources */,
 				F3D1F7AC225CC21A006DC162 /* IntroViewController.swift in Sources */,
 				F3C0DFA3233369CE00E49425 /* NoticeListView.swift in Sources */,
+				F306022A2379812300A9C866 /* MainViewReactor.swift in Sources */,
 				F3F5413D232778D100D618D2 /* TimeSetManageViewCoordinator.swift in Sources */,
 				F3D1F7BF225CC357006DC162 /* UIColor+hex.swift in Sources */,
 				F37AF0E622F8211800509F5F /* AlertBuilder.swift in Sources */,

--- a/timer.xcodeproj/project.pbxproj
+++ b/timer.xcodeproj/project.pbxproj
@@ -190,6 +190,7 @@
 		F3F800A7226A0981003D1D88 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3D1F7C2225CC3D7006DC162 /* Constants.swift */; };
 		F3F800B1226A0C15003D1D88 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = F3F800B3226A0C15003D1D88 /* Localizable.strings */; };
 		F3F800B6226A0D0F003D1D88 /* String+localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F800B5226A0D0F003D1D88 /* String+localized.swift */; };
+		F3F97A8E2378111F0041341B /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F97A8D2378111F0041341B /* Toast.swift */; };
 		F3FBFFE722F420B6001E369E /* Footer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3FBFFE622F420B6001E369E /* Footer.swift */; };
 /* End PBXBuildFile section */
 
@@ -413,6 +414,7 @@
 		F3F800B2226A0C15003D1D88 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		F3F800B4226A0C3F003D1D88 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		F3F800B5226A0D0F003D1D88 /* String+localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+localized.swift"; sourceTree = "<group>"; };
+		F3F97A8D2378111F0041341B /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
 		F3FBFFE622F420B6001E369E /* Footer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Footer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1015,6 +1017,7 @@
 				F33408FE22D0D8BC008661EC /* TimerBadgeView */,
 				F38702AD22F899720099241C /* HeaderView */,
 				F3CD184422F6167B008DB221 /* FooterView */,
+				F3F97A8C237810C00041341B /* Toast */,
 				F31CD7B822F7479F0038A2DE /* TimerInputView.swift */,
 				F35E05FE22FF023D00A66ED9 /* TimeKeyPad.swift */,
 				F3D49923227F273E00AC4B2B /* NumberKeyPad.swift */,
@@ -1100,6 +1103,14 @@
 				F3F5F879233221D7003271B3 /* SettingTableViewCell.swift */,
 			);
 			path = Cell;
+			sourceTree = "<group>";
+		};
+		F3F97A8C237810C00041341B /* Toast */ = {
+			isa = PBXGroup;
+			children = (
+				F3F97A8D2378111F0041341B /* Toast.swift */,
+			);
+			path = Toast;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1466,6 +1477,7 @@
 				F3DD7AD423216282000E3BB9 /* SavedTimeSetCollectionViewCell.swift in Sources */,
 				F3ADF4352312945600FA9277 /* TimeSetMemoViewCoordinator.swift in Sources */,
 				F3F541432327E07500D618D2 /* TimeSetManageCollectionViewCell.swift in Sources */,
+				F3F97A8E2378111F0041341B /* Toast.swift in Sources */,
 				F309F97B22E9883100C280A0 /* TimerOptionView.swift in Sources */,
 				F38702B722F970E80099241C /* TimeSetDetailViewCoordinator.swift in Sources */,
 				F3C0DF8923333F9F00E49425 /* CountdownSettingViewReactor.swift in Sources */,

--- a/timer/Resource/en.lproj/Localizable.strings
+++ b/timer/Resource/en.lproj/Localizable.strings
@@ -167,6 +167,9 @@
 "alert_button_init" = "Initialize";
 "alert_button_delete" = "Delete";
 
+// MARK: - Toast
+"toast_alarm_all_apply_title" = "All timer alarm set [%@].";
+
 // MARK: - Setting
 "setting_version_lastest_title" = "Lastest!";
 "setting_version_need_update_title" = "Update!";

--- a/timer/Resource/en.lproj/Localizable.strings
+++ b/timer/Resource/en.lproj/Localizable.strings
@@ -172,7 +172,11 @@
 "toast_time_set_timer_selected_title" = "Time set will be start from selected timer.";
 "toast_time_set_add_bookmark_title" = "Time set added to your bookmarks!";
 "toast_time_set_remove_bookmark_title" = "Time set removed from your bookmarks!";
+"toast_time_set_end_cancel_title" = "Try to write memo that why time set canceled!";
+"toast_time_set_end_overtime_title" = "Try to write memo that why time set record overtime!";
 "toast_team_info_copy_email_title" = "Copied to clipboard!";
+
+"toast_task_memo_title" = "Memo";
 
 // MARK: - Setting
 "setting_version_lastest_title" = "Lastest!";

--- a/timer/Resource/en.lproj/Localizable.strings
+++ b/timer/Resource/en.lproj/Localizable.strings
@@ -169,6 +169,9 @@
 
 // MARK: - Toast
 "toast_alarm_all_apply_title" = "All timer alarm set [%@].";
+"toast_time_set_timer_selected_title" = "Time set will be start from selected timer.";
+"toast_time_set_add_bookmark_title" = "Time set added to your bookmarks!";
+"toast_time_set_remove_bookmark_title" = "Time set removed from your bookmarks!";
 
 // MARK: - Setting
 "setting_version_lastest_title" = "Lastest!";

--- a/timer/Resource/en.lproj/Localizable.strings
+++ b/timer/Resource/en.lproj/Localizable.strings
@@ -172,6 +172,7 @@
 "toast_time_set_timer_selected_title" = "Time set will be start from selected timer.";
 "toast_time_set_add_bookmark_title" = "Time set added to your bookmarks!";
 "toast_time_set_remove_bookmark_title" = "Time set removed from your bookmarks!";
+"toast_team_info_copy_email_title" = "Copied to clipboard!";
 
 // MARK: - Setting
 "setting_version_lastest_title" = "Lastest!";

--- a/timer/Resource/ko.lproj/Localizable.strings
+++ b/timer/Resource/ko.lproj/Localizable.strings
@@ -167,6 +167,9 @@
 "alert_button_init" = "초기화";
 "alert_button_delete" = "삭제";
 
+// MARK: - Toast
+"toast_alarm_all_apply_title" = "모든 타이머의 사운드가 %@으로 지정되었어요.";
+
 // MARK: - Setting
 "setting_version_lastest_title" = "최신버전입니다!";
 "setting_version_need_update_title" = "업데이트가 필요해요!";

--- a/timer/Resource/ko.lproj/Localizable.strings
+++ b/timer/Resource/ko.lproj/Localizable.strings
@@ -169,6 +169,9 @@
 
 // MARK: - Toast
 "toast_alarm_all_apply_title" = "모든 타이머의 사운드가 %@으로 지정되었어요.";
+"toast_time_set_timer_selected_title" = "선택한 타이머부터 시작돼요.";
+"toast_time_set_add_bookmark_title" = "즐겨찾기에 추가되었어요!";
+"toast_time_set_remove_bookmark_title" = "즐겨찾기에서 삭제되었어요!";
 
 // MARK: - Setting
 "setting_version_lastest_title" = "최신버전입니다!";

--- a/timer/Resource/ko.lproj/Localizable.strings
+++ b/timer/Resource/ko.lproj/Localizable.strings
@@ -172,6 +172,7 @@
 "toast_time_set_timer_selected_title" = "선택한 타이머부터 시작돼요.";
 "toast_time_set_add_bookmark_title" = "즐겨찾기에 추가되었어요!";
 "toast_time_set_remove_bookmark_title" = "즐겨찾기에서 삭제되었어요!";
+"toast_team_info_copy_email_title" = "클립보드에 복사되었어요!";
 
 // MARK: - Setting
 "setting_version_lastest_title" = "최신버전입니다!";

--- a/timer/Resource/ko.lproj/Localizable.strings
+++ b/timer/Resource/ko.lproj/Localizable.strings
@@ -172,7 +172,11 @@
 "toast_time_set_timer_selected_title" = "선택한 타이머부터 시작돼요.";
 "toast_time_set_add_bookmark_title" = "즐겨찾기에 추가되었어요!";
 "toast_time_set_remove_bookmark_title" = "즐겨찾기에서 삭제되었어요!";
+"toast_time_set_end_cancel_title" = "왜 타이머를 취소했는지 기록해보세요!";
+"toast_time_set_end_overtime_title" = "왜 타이머를 초과 기록했는지 기록해보세요!";
 "toast_team_info_copy_email_title" = "클립보드에 복사되었어요!";
+
+"toast_task_memo_title" = "메모 작성";
 
 // MARK: - Setting
 "setting_version_lastest_title" = "최신버전입니다!";

--- a/timer/Source/Extension/UIView+autolayout.swift
+++ b/timer/Source/Extension/UIView+autolayout.swift
@@ -10,6 +10,14 @@ import Foundation
 import UIKit
 
 extension UIView {
+    var _safeAreaInsets: UIEdgeInsets {
+        if #available(iOS 11.0, *) {
+            return safeAreaInsets
+        } else {
+            return .zero
+        }
+    }
+    
     func addAutolayoutSubview(_ subview: UIView) {
         subview.translatesAutoresizingMaskIntoConstraints = false
         self.addSubview(subview)

--- a/timer/Source/Extension/UIViewController+child.swift
+++ b/timer/Source/Extension/UIViewController+child.swift
@@ -33,7 +33,10 @@ extension UIViewController {
         if isModal {
             dismiss(animated: animated, completion: completion)
         } else {
-            navigationController?.popViewController(animated: animated)
+            guard var viewControllers = navigationController?.viewControllers,
+                let index = navigationController?.viewControllers.firstIndex(of: self) else { return }
+            viewControllers.remove(at: index)
+            navigationController?.setViewControllers(viewControllers, animated: animated)
         }
     }
     

--- a/timer/Source/Module/AlarmSetting/AlarmSettingViewController.swift
+++ b/timer/Source/Module/AlarmSetting/AlarmSettingViewController.swift
@@ -84,18 +84,6 @@ class AlarmSettingViewController: BaseHeaderViewController, View {
             .disposed(by: disposeBag)
     }
     
-    // MARK: - action method
-    /// Handle header button tap action according to button type
-    private func headerActionHandler(type: CommonHeader.ButtonType) {
-        switch type {
-        case .back:
-            navigationController?.popViewController(animated: true)
-            
-        default:
-            break
-        }
-    }
-    
     deinit {
         Logger.verbose()
     }

--- a/timer/Source/Module/AlarmSetting/AlarmSettingViewController.swift
+++ b/timer/Source/Module/AlarmSetting/AlarmSettingViewController.swift
@@ -61,7 +61,7 @@ class AlarmSettingViewController: BaseHeaderViewController, View {
     func bind(reactor: AlarmSettingViewReactor) {
         // MARK: action
         rx.viewDidLoad
-            .map { Reactor.Action.viewDidLoad }
+            .map { Reactor.Action.load }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         

--- a/timer/Source/Module/AlarmSetting/AlarmSettingViewReactor.swift
+++ b/timer/Source/Module/AlarmSetting/AlarmSettingViewReactor.swift
@@ -11,8 +11,8 @@ import ReactorKit
 
 class AlarmSettingViewReactor: Reactor {
     enum Action {
-        /// Load countdown menu items when view did load
-        case viewDidLoad
+        /// Load countdown menu items
+        case load
         
         /// Select menu
         case select(IndexPath)
@@ -55,8 +55,8 @@ class AlarmSettingViewReactor: Reactor {
     // MARK: - mutation
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case .viewDidLoad:
-            return actionViewDidLoad()
+        case .load:
+            return actionLoad()
             
         case let .select(indexPath):
             return actionSelect(indexPath: indexPath)
@@ -84,7 +84,7 @@ class AlarmSettingViewReactor: Reactor {
     }
     
     // MARK: - action method
-    private func actionViewDidLoad() -> Observable<Mutation> {
+    private func actionLoad() -> Observable<Mutation> {
         let items = Alarm.allCases
         
         var indexPath = IndexPath(item: 0, section: 0)

--- a/timer/Source/Module/Common/TimerOptionView/TimerOptionView.swift
+++ b/timer/Source/Module/Common/TimerOptionView/TimerOptionView.swift
@@ -549,7 +549,8 @@ extension Reactive where Base: TimerOptionView {
         return ControlEvent(events: base.deleteButton.rx.tap)
     }
     
-    var tapApplyAll: ControlEvent<Void> {
-        return ControlEvent(events: base.alarmApplyAllButton.rx.tap)
+    var tapApplyAll: ControlEvent<Alarm> {
+        return ControlEvent(events: base.alarmApplyAllButton.rx.tap
+            .withLatestFrom(base.reactor?.state.map { $0.alarm } ?? .empty()))
     }
 }

--- a/timer/Source/Module/Common/Toast/Toast.swift
+++ b/timer/Source/Module/Common/Toast/Toast.swift
@@ -1,0 +1,299 @@
+//
+//  Toast.swift
+//  timer
+//
+//  Created by JSilver on 2019/11/10.
+//  Copyright © 2019 Jeong Jin Eun. All rights reserved.
+//
+
+import UIKit
+import RxSwift
+
+struct ToastTask {
+    let title: String
+    let handler: () -> Void
+}
+
+class Toast: UIView {
+    // MARK: - constants
+    private static let ANIMATION_DURATION: TimeInterval = 0.5
+    private static let AUTOMATIC_POSITION: CGPoint = CGPoint(x: -1, y: -1)
+    
+    // MARK: - view properties
+    let contentLabel: UILabel = {
+        let view = UILabel()
+        view.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        view.numberOfLines = 0
+        
+        var paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 6.adjust()
+        
+        var attributes: [NSAttributedString.Key: Any] = [
+            .font: Constants.Font.Bold.withSize(12.adjust()),
+            .foregroundColor: Constants.Color.alabaster,
+            .kern: -0.36,
+            .paragraphStyle: paragraphStyle
+        ]
+        
+        view.attributedText = NSAttributedString(string: " ", attributes: attributes)
+        return view
+    }()
+    
+    private lazy var contentContainerView: UIView = {
+        let view = UIView()
+        
+        // Set constraint of subview
+        view.addAutolayoutSubview(contentLabel)
+        contentLabel.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(20.adjust())
+            make.trailing.equalToSuperview().inset(20.adjust()).priorityMedium()
+            make.centerY.equalToSuperview()
+        }
+        
+        return view
+    }()
+    
+    let taskButton: UIButton = {
+        let view = UIButton()
+        
+        var attributes: [NSAttributedString.Key: Any] = [
+            .font: Constants.Font.Bold.withSize(10.adjust()),
+            .foregroundColor: Constants.Color.codGray,
+            .kern: -0.3
+        ]
+        
+        view.setAttributedTitle(NSAttributedString(string: " ", attributes: attributes), for: .normal)
+        return view
+    }()
+    
+    private lazy var contentStackView: UIStackView = {
+        let view = UIStackView(arrangedSubviews: [contentContainerView])
+        view.axis = .horizontal
+        return view
+    }()
+    
+    private var backgroundLayer: CAShapeLayer = {
+        let layer = CAShapeLayer()
+        layer.fillColor = Constants.Color.codGray.cgColor
+        return layer
+    }()
+    
+    private var taskBorderLayer: CAShapeLayer = {
+        let layer = CAShapeLayer()
+        layer.lineWidth = 1
+        layer.strokeColor = Constants.Color.codGray.cgColor
+        layer.fillColor = Constants.Color.alabaster.cgColor
+        return layer
+    }()
+    
+    // MARK: - properties
+    private var keyWindow: UIWindow? = UIApplication.shared.keyWindow
+    private var content: String
+    private var task: ToastTask?
+    
+    private var disposeBag: DisposeBag = DisposeBag()
+    
+    // MARK: - constructor
+    init(origin: CGPoint = Toast.AUTOMATIC_POSITION, content: String, task: ToastTask? = nil) {
+        self.content = content
+        self.task = task
+        super.init(frame: CGRect(origin: origin, size: .zero))
+        
+        initLayout()
+        bind()
+        
+        // Set constarint of subviews
+        addAutolayoutSubview(contentStackView)
+        contentStackView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - lifecycle
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        // Set toast size
+        let labelWidth: CGFloat = task == nil ? 290.adjust() : 232.adjust()
+        let height = max(48.adjust(), contentLabel.sizeThatFits(CGSize(width: labelWidth, height: 0)).height + 16.adjust())
+        frame.size = CGSize(width: 330.adjust(), height: height)
+        
+        if let keyWindow = keyWindow, frame.origin == Self.AUTOMATIC_POSITION {
+            // Set toast position automatically (center x, 86% y)
+            let x = (keyWindow.bounds.width - bounds.width) * 0.5
+            let y = (keyWindow.bounds.height - bounds.height - keyWindow._safeAreaInsets.bottom) * 0.86
+            frame.origin = CGPoint(x: x, y: y)
+        }
+    }
+    
+    override func draw(_ rect: CGRect) {
+        backgroundLayer.frame = bounds
+        taskBorderLayer.frame = taskButton.bounds.insetBy(dx: 0.5, dy: 0.5)
+        
+        backgroundLayer.path = drawBackgroundLayer(frame: bounds, corner: 5.adjust()).cgPath
+        taskBorderLayer.path = drawTaskBorderLayer(frame: taskBorderLayer.bounds, corner: 5.adjust()).cgPath
+    }
+    
+    // MARK: - bind
+    private func bind() {
+        taskButton.rx.tap
+            .do(onNext: { UIImpactFeedbackGenerator(style: .light).impactOccurred() })
+            .do(onNext: { [weak self] in self?.dismiss(animated: true) })
+            .subscribe(onNext: { [weak self] in self?.task?.handler() })
+            .disposed(by: disposeBag)
+    }
+    
+    // MARK: - private method
+    private func initLayout() {
+        alpha = 0
+        // Add sub border layer
+        layer.addSublayer(backgroundLayer)
+        taskButton.layer.addSublayer(taskBorderLayer)
+        
+        // Set default content & task
+        setContent(content)
+        if let task = task {
+            setTask(task)
+        }
+    }
+    
+    private func setContent(_ content: String) {
+        guard let attributedString = contentLabel.attributedText?.mutableCopy() as? NSMutableAttributedString else { return }
+        attributedString.mutableString.setString(content)
+        // Set content label's attributed text
+        contentLabel.attributedText = attributedString
+        
+        self.content = content
+    }
+    
+    private func setTask(_ task: ToastTask) {
+        guard let attributedString = taskButton.attributedTitle(for: .normal)?.mutableCopy() as? NSMutableAttributedString else { return }
+        attributedString.mutableString.setString(task.title)
+        // Set task button's attributed text
+        taskButton.setAttributedTitle(attributedString, for: .normal)
+        
+        // Set constraint of task button
+        contentStackView.addArrangedSubview(taskButton)
+        taskButton.snp.makeConstraints { make in
+            make.width.equalTo(68.adjust()).priorityHigh()
+        }
+        
+        self.task = task
+    }
+    
+    // Draw background layer
+    private func drawBackgroundLayer(frame: CGRect, corner radius: CGFloat) -> UIBezierPath {
+        // Initial point of border path
+        let initialPoint = CGPoint(x: radius, y: 0)
+        // Round corner points
+        let cornerPoints: [(CGPoint, CGPoint?, CGPoint?)] = [
+            // Left-Top
+            (CGPoint(x: 0, y: radius),
+             CGPoint(x: radius * 0.5, y: 0),
+             CGPoint(x: 0, y: radius * 0.5)),
+            // Left-Bottom
+            (CGPoint(x: 0, y: frame.height - radius), nil, nil),
+            (CGPoint(x: radius, y: frame.height),
+             CGPoint(x: 0, y: frame.height - radius * 0.5),
+             CGPoint(x: radius * 0.5, y: frame.height)),
+            // Right-Bottom
+            (CGPoint(x: frame.width - radius, y: frame.height), nil, nil),
+            (CGPoint(x: frame.width, y: frame.height - radius),
+             CGPoint(x: frame.width - radius * 0.5, y: frame.height),
+             CGPoint(x: frame.width, y: frame.height - radius * 0.5)),
+            // Right-Top
+            (CGPoint(x: frame.width, y: radius), nil, nil),
+            (CGPoint(x: frame.width - radius, y: 0),
+             CGPoint(x: frame.width, y: radius * 0.5),
+             CGPoint(x: frame.width - radius * 0.5, y: 0))
+        ]
+        
+        // Draw path
+        let path = UIBezierPath()
+        path.move(to: initialPoint)
+        
+        cornerPoints.forEach {
+            if let controlPoint1 = $0.1, let controlPoint2 = $0.2 {
+                path.addCurve(to: $0.0, controlPoint1: controlPoint1, controlPoint2: controlPoint2)
+            } else {
+                path.addLine(to: $0.0)
+            }
+        }
+        
+        return path
+    }
+    
+    // Draw task border layer
+    private func drawTaskBorderLayer(frame: CGRect, corner radius: CGFloat) -> UIBezierPath {
+        // Initial point of border path
+        let initialPoint = CGPoint(x: 0, y: 0)
+        // Round corner points
+        let cornerPoints: [(CGPoint, CGPoint?, CGPoint?)] = [
+            // Left-Bottom
+            (CGPoint(x: 0, y: frame.height), nil, nil),
+            // Right-Bottom
+            (CGPoint(x: frame.width - radius, y: frame.height), nil, nil),
+            (CGPoint(x: frame.width, y: frame.height - radius),
+             CGPoint(x: frame.width - radius * 0.5, y: frame.height),
+             CGPoint(x: frame.width, y: frame.height - radius * 0.5)),
+            // Right-Top
+            (CGPoint(x: frame.width, y: radius), nil, nil),
+            (CGPoint(x: frame.width - radius, y: 0),
+             CGPoint(x: frame.width, y: radius * 0.5),
+             CGPoint(x: frame.width - radius * 0.5, y: 0)),
+            // Left-Top
+            (CGPoint(x: -0.5, y: 0), nil, nil)
+        ]
+        
+        // Draw path
+        let path = UIBezierPath()
+        path.move(to: initialPoint)
+        
+        cornerPoints.forEach {
+            if let controlPoint1 = $0.1, let controlPoint2 = $0.2 {
+                path.addCurve(to: $0.0, controlPoint1: controlPoint1, controlPoint2: controlPoint2)
+            } else {
+                path.addLine(to: $0.0)
+            }
+        }
+        
+        return path
+    }
+    
+    // MARK: - public method
+    func show(animated: Bool, withDuration: TimeInterval = -1) {
+        guard let keyWindow = keyWindow else { return }
+        keyWindow.addSubview(self)
+        
+        if animated {
+            UIViewPropertyAnimator.runningPropertyAnimator(withDuration: Self.ANIMATION_DURATION, delay: 0, animations: {
+                self.alpha = 1
+            })
+        } else {
+            alpha = 1
+        }
+        
+        if withDuration > 0 {
+            Observable<Int>.interval(.milliseconds(Int(withDuration * 1000)), scheduler: MainScheduler.instance)
+                .take(1)
+                .subscribe(onNext: { [weak self] _ in self?.dismiss(animated: animated) })
+                .disposed(by: disposeBag)
+        }
+    }
+    
+    func dismiss(animated: Bool) {
+        if animated {
+            UIViewPropertyAnimator.runningPropertyAnimator(withDuration: Self.ANIMATION_DURATION, delay: 0, animations: {
+                self.alpha = 0
+            }, completion: { _ in
+                self.removeFromSuperview()
+            })
+        } else {
+            alpha = 0
+        }
+    }
+}

--- a/timer/Source/Module/CountdownSetting/CountdownSettingViewController.swift
+++ b/timer/Source/Module/CountdownSetting/CountdownSettingViewController.swift
@@ -84,9 +84,6 @@ class CountdownSettingViewController: BaseHeaderViewController, View {
             .disposed(by: disposeBag)
     }
     
-    // MARK: - action method
-    // MARK: - state method
-    
     deinit {
         Logger.verbose()
     }

--- a/timer/Source/Module/CountdownSetting/CountdownSettingViewController.swift
+++ b/timer/Source/Module/CountdownSetting/CountdownSettingViewController.swift
@@ -61,7 +61,7 @@ class CountdownSettingViewController: BaseHeaderViewController, View {
     func bind(reactor: CountdownSettingViewReactor) {
         // MARK: action
         rx.viewDidLoad
-            .map { Reactor.Action.viewDidLoad }
+            .map { Reactor.Action.load }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         

--- a/timer/Source/Module/CountdownSetting/CountdownSettingViewReactor.swift
+++ b/timer/Source/Module/CountdownSetting/CountdownSettingViewReactor.swift
@@ -11,8 +11,8 @@ import ReactorKit
 
 class CountdownSettingViewReactor: Reactor {
     enum Action {
-        /// Load countdown menu items when view did load
-        case viewDidLoad
+        /// Load countdown menu items
+        case load
         
         /// Select menu
         case select(IndexPath)
@@ -55,8 +55,8 @@ class CountdownSettingViewReactor: Reactor {
     // MARK: - mutation
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case .viewDidLoad:
-            return actionViewDidLoad()
+        case .load:
+            return actionLoad()
             
         case let .select(indexPath):
             return actionSelect(indexPath: indexPath)
@@ -84,7 +84,7 @@ class CountdownSettingViewReactor: Reactor {
     }
     
     // MARK: - action method
-    private func actionViewDidLoad() -> Observable<Mutation> {
+    private func actionLoad() -> Observable<Mutation> {
         let items: [CountdownSettingMenu] = [
             CountdownSettingMenu(seconds: 5),
             CountdownSettingMenu(seconds: 10),

--- a/timer/Source/Module/Intro/IntroViewCoordinator.swift
+++ b/timer/Source/Module/Intro/IntroViewCoordinator.swift
@@ -47,10 +47,12 @@ class IntroViewCoordinator: NSObject, CoordinatorProtocol {
         switch route {
         case .main:
             let coordinator = MainViewCoordinator(provider: provider)
+            let reactor = MainViewReactor(timeSetService: provider.timeSetService)
             let viewController = MainViewController(coordinator: coordinator)
             
             // DI
             coordinator.viewController = viewController
+            viewController.reactor = reactor
             
             // set tab bar view controller initial index
             viewController.select(at: MainViewController.TabType.productivity.rawValue, animated: false)

--- a/timer/Source/Module/Main/MainViewCoordinator.swift
+++ b/timer/Source/Module/Main/MainViewCoordinator.swift
@@ -15,6 +15,7 @@ class MainViewCoordinator: CoordinatorProtocol {
         case productivity
         case local
         case timeSetProcess(TimeSetItem)
+        case historyDetail(History)
     }
     
     weak var viewController: MainViewController!
@@ -35,6 +36,9 @@ class MainViewCoordinator: CoordinatorProtocol {
             }
             let viewControllers = [rootViewController, viewController]
             self.viewController.navigationController?.setViewControllers(viewControllers, animated: true)
+            
+        case .historyDetail(_):
+            self.viewController.navigationController?.pushViewController(viewController, animated: true)
             
         default:
             break
@@ -71,6 +75,17 @@ class MainViewCoordinator: CoordinatorProtocol {
             let coordinator = TimeSetProcessViewCoordinator(provider: provider)
             guard let reactor = TimeSetProcessViewReactor(appService: provider.appService, timeSetService: provider.timeSetService, timeSetItem: timeSetItem) else { return nil }
             let viewController = TimeSetProcessViewController(coordinator: coordinator)
+            
+            // DI
+            coordinator.viewController = viewController
+            viewController.reactor = reactor
+            
+            return viewController
+            
+        case let .historyDetail(history):
+            let coordinator = HistoryDetailViewCoordinator(provider: provider)
+            let reactor = HistoryDetailViewReactor(timeSetService: provider.timeSetService, history: history)
+            let viewController = HistoryDetailViewController(coordinator: coordinator)
             
             // DI
             coordinator.viewController = viewController

--- a/timer/Source/Module/Main/MainViewReactor.swift
+++ b/timer/Source/Module/Main/MainViewReactor.swift
@@ -15,22 +15,20 @@ class MainViewReactor: Reactor {
     }
     
     enum Mutation {
-        case setPreviousTimeSetEndState(History.EndState?)
+        case setPreviousHistory(History)
         
         case timeSetEnded
     }
     
     struct State {
-        var previousTimeSetEndState: History.EndState?
-        
         var didTimeSetEnded: Bool
+
+        var previousHistory: History?
     }
     
     // MARK: - properties
     var initialState: State
     private var timeSetService: TimeSetServiceProtocol
-    
-    var previousTimeSet: TimeSetItem?
     
     // MARK: - constructor
     init(timeSetService: TimeSetServiceProtocol) {
@@ -41,8 +39,8 @@ class MainViewReactor: Reactor {
     // MARK: - mutation
     func mutate(timeSetEvent: TimeSetEvent) -> Observable<Mutation> {
         switch timeSetEvent {
-        case let .ended(endState, timeSetItem):
-            return actionTimeSetEnded(endState, item: timeSetItem)
+        case let .ended(history):
+            return actionTimeSetEnded(history: history)
             
         default:
             return .empty()
@@ -62,8 +60,8 @@ class MainViewReactor: Reactor {
         state.didTimeSetEnded = false
         
         switch mutation {
-        case let .setPreviousTimeSetEndState(endState):
-            state.previousTimeSetEndState = endState
+        case let .setPreviousHistory(history):
+            state.previousHistory = history
             return state
             
         case .timeSetEnded:
@@ -73,21 +71,9 @@ class MainViewReactor: Reactor {
     }
     
     // MARK: - action method
-    private func actionTimeSetEnded(_ endState: History.EndState, item: TimeSetItem) -> Observable<Mutation> {
-        previousTimeSet = item
-        
-        var setPreviousTimeSetEndState: Observable<Mutation> = .just(.setPreviousTimeSetEndState(nil))
-        switch endState {
-        case .cancel,
-             .overtime:
-            setPreviousTimeSetEndState = .just(.setPreviousTimeSetEndState(endState))
-            
-        default:
-            break
-        }
-        
+    private func actionTimeSetEnded(history: History) -> Observable<Mutation> {
         return .concat(
-            setPreviousTimeSetEndState,
+            .just(.setPreviousHistory(history)),
             .just(.timeSetEnded)
         )
     }

--- a/timer/Source/Module/Main/MainViewReactor.swift
+++ b/timer/Source/Module/Main/MainViewReactor.swift
@@ -1,0 +1,98 @@
+//
+//  MainViewReactor.swift
+//  timer
+//
+//  Created by JSilver on 2019/11/11.
+//  Copyright © 2019 Jeong Jin Eun. All rights reserved.
+//
+
+import RxSwift
+import ReactorKit
+
+class MainViewReactor: Reactor {
+    enum Action {
+        
+    }
+    
+    enum Mutation {
+        case setPreviousTimeSetEndState(History.EndState?)
+        
+        case timeSetEnded
+    }
+    
+    struct State {
+        var previousTimeSetEndState: History.EndState?
+        
+        var didTimeSetEnded: Bool
+    }
+    
+    // MARK: - properties
+    var initialState: State
+    private var timeSetService: TimeSetServiceProtocol
+    
+    var previousTimeSet: TimeSetItem?
+    
+    // MARK: - constructor
+    init(timeSetService: TimeSetServiceProtocol) {
+        self.timeSetService = timeSetService
+        initialState = State(didTimeSetEnded: false)
+    }
+    
+    // MARK: - mutation
+    func mutate(timeSetEvent: TimeSetEvent) -> Observable<Mutation> {
+        switch timeSetEvent {
+        case let .ended(endState, timeSetItem):
+            return actionTimeSetEnded(endState, item: timeSetItem)
+            
+        default:
+            return .empty()
+        }
+    }
+    
+    func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
+        let timeSetEventMutation = timeSetService.event
+            .flatMap { [weak self] in self?.mutate(timeSetEvent: $0) ?? .empty() }
+        
+        return .merge(mutation, timeSetEventMutation)
+    }
+    
+    // MARK: - reduce
+    func reduce(state: State, mutation: Mutation) -> State {
+        var state = state
+        state.didTimeSetEnded = false
+        
+        switch mutation {
+        case let .setPreviousTimeSetEndState(endState):
+            state.previousTimeSetEndState = endState
+            return state
+            
+        case .timeSetEnded:
+            state.didTimeSetEnded = true
+            return state
+        }
+    }
+    
+    // MARK: - action method
+    private func actionTimeSetEnded(_ endState: History.EndState, item: TimeSetItem) -> Observable<Mutation> {
+        previousTimeSet = item
+        
+        var setPreviousTimeSetEndState: Observable<Mutation> = .just(.setPreviousTimeSetEndState(nil))
+        switch endState {
+        case .cancel,
+             .overtime:
+            setPreviousTimeSetEndState = .just(.setPreviousTimeSetEndState(endState))
+            
+        default:
+            break
+        }
+        
+        return .concat(
+            setPreviousTimeSetEndState,
+            .just(.timeSetEnded)
+        )
+    }
+    
+    deinit {
+        Logger.verbose()
+    }
+}

--- a/timer/Source/Module/Main/Productivity/ProductivityViewController.swift
+++ b/timer/Source/Module/Main/Productivity/ProductivityViewController.swift
@@ -151,6 +151,7 @@ class ProductivityViewController: BaseHeaderViewController, View {
     func bind(reactor: TimeSetEditViewReactor) {
         // DI
         timerOptionView.reactor = reactor.timerOptionViewReactor
+        bind(timerOption: timerOptionView)
         
         // MARK: action
         timerClearButton.rx.tap
@@ -194,16 +195,6 @@ class ProductivityViewController: BaseHeaderViewController, View {
             .bind(to: isTimerOptionVisible)
             .disposed(by: disposeBag)
         
-        timerOptionView.rx.tapApplyAll
-            .map { Reactor.Action.alarmApplyAll }
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
-        
-        timerOptionView.rx.tapDelete
-            .do(onNext: { [weak self] in self?.isTimerOptionVisible.accept(false) })
-            .map { Reactor.Action.deleteTimer }
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
         
         saveButton.rx.tap
             .map { Reactor.Action.saveTimeSet }
@@ -316,6 +307,22 @@ class ProductivityViewController: BaseHeaderViewController, View {
             .withLatestFrom(reactor.state.map { $0.selectedIndex })
             .map { IndexPath(item: $0, section: TimerBadgeSectionType.regular.rawValue) }
             .subscribe(onNext: { [weak self] in self?.badgeScrollIfCan(at: $0) })
+            .disposed(by: disposeBag)
+    }
+    
+    private func bind(timerOption view: TimerOptionView) {
+        guard let reactor = reactor else { return }
+        
+        view.rx.tapApplyAll
+            .do(onNext: { Toast(content: String(format: "toast_alarm_all_apply_title".localized, $0.title)).show(animated: true, withDuration: 3) })
+            .map { Reactor.Action.alarmApplyAll($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        view.rx.tapDelete
+            .do(onNext: { [weak self] in self?.isTimerOptionVisible.accept(false) })
+            .map { Reactor.Action.deleteTimer }
+            .bind(to: reactor.action)
             .disposed(by: disposeBag)
     }
 

--- a/timer/Source/Module/NoticeList/NoticeDetail/NoticeDetailViewController.swift
+++ b/timer/Source/Module/NoticeList/NoticeDetail/NoticeDetailViewController.swift
@@ -52,7 +52,7 @@ class NoticeDetailViewController: BaseHeaderViewController, View {
     func bind(reactor: NoticeDetailViewReactor) {
         // MARK: action
         rx.viewDidLoad
-            .map { Reactor.Action.viewDidLoad }
+            .map { Reactor.Action.refresh }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         

--- a/timer/Source/Module/NoticeList/NoticeDetail/NoticeDetailViewReactor.swift
+++ b/timer/Source/Module/NoticeList/NoticeDetail/NoticeDetailViewReactor.swift
@@ -11,8 +11,8 @@ import ReactorKit
 
 class NoticeDetailViewReactor: Reactor {
     enum Action {
-        /// Load notice content when view did load
-        case viewDidLoad
+        /// Load notice content to refresh
+        case refresh
     }
     
     enum Mutation {
@@ -53,8 +53,8 @@ class NoticeDetailViewReactor: Reactor {
     // MARK: - mutation
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case .viewDidLoad:
-            return actionViewDidLoad()
+        case .refresh:
+            return actionRefresh()
         }
     }
     
@@ -74,7 +74,7 @@ class NoticeDetailViewReactor: Reactor {
     }
     
     // MARK: - action method
-    private func actionViewDidLoad() -> Observable<Mutation> {
+    private func actionRefresh() -> Observable<Mutation> {
         let startLoading: Observable<Mutation> = .just(.setLoading(true))
         let requestNoticeDetail: Observable<Mutation> = networkService.requestNoticeDetail(notice.id).asObservable()
             .flatMap { Observable<Mutation>.just(.setContent($0.content)) }

--- a/timer/Source/Module/NoticeList/NoticeListViewController.swift
+++ b/timer/Source/Module/NoticeList/NoticeListViewController.swift
@@ -65,7 +65,7 @@ class NoticeListViewController: BaseHeaderViewController, View {
     func bind(reactor: NoticeListViewReactor) {
         // MARK: action
         rx.viewDidLoad
-            .map { Reactor.Action.viewDidLoad }
+            .map { Reactor.Action.refresh }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         

--- a/timer/Source/Module/NoticeList/NoticeListViewReactor.swift
+++ b/timer/Source/Module/NoticeList/NoticeListViewReactor.swift
@@ -11,8 +11,8 @@ import ReactorKit
 
 class NoticeListViewReactor: Reactor {
     enum Action {
-        /// Load notice list when view did load
-        case viewDidLoad
+        /// Load notice list to refresh
+        case refresh
     }
     
     enum Mutation {
@@ -50,8 +50,8 @@ class NoticeListViewReactor: Reactor {
     // MARK: - mutation
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case .viewDidLoad:
-            return actionViewDidLoad()
+        case .refresh:
+            return actionRefresh()
         }
     }
     
@@ -76,7 +76,7 @@ class NoticeListViewReactor: Reactor {
     }
     
     // MARK: - action method
-    private func actionViewDidLoad() -> Observable<Mutation> {
+    private func actionRefresh() -> Observable<Mutation> {
         let startLoading: Observable<Mutation> = .just(.setLoading(true))
         let requestNoticeList: Observable<Mutation> = networkService.requestNoticeList().asObservable()
             .flatMap { notices -> Observable<Mutation> in

--- a/timer/Source/Module/OpenSourceLicense/OpenSourceLicenseViewController.swift
+++ b/timer/Source/Module/OpenSourceLicense/OpenSourceLicenseViewController.swift
@@ -50,7 +50,7 @@ class OpenSourceLicenseViewController: BaseHeaderViewController, View {
     func bind(reactor: OpenSourceLicenseViewReactor) {
         // MARK: action
         rx.viewDidLoad
-            .map { Reactor.Action.viewDidLoad }
+            .map { Reactor.Action.load }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         

--- a/timer/Source/Module/OpenSourceLicense/OpenSourceLicenseViewController.swift
+++ b/timer/Source/Module/OpenSourceLicense/OpenSourceLicenseViewController.swift
@@ -73,17 +73,6 @@ class OpenSourceLicenseViewController: BaseHeaderViewController, View {
     }
     
     // MARK: - action method
-    /// Handle header button tap action according to button type
-    private func headerActionHandler(type: CommonHeader.ButtonType) {
-        switch type {
-        case .back:
-            navigationController?.popViewController(animated: true)
-
-        default:
-            break
-        }
-    }
-    
     // MARK: - state method
     /// Get license attributed text from data
     private func getLicenseAttributedText(data: Data) -> NSAttributedString? {

--- a/timer/Source/Module/OpenSourceLicense/OpensourceLicenseViewReactor.swift
+++ b/timer/Source/Module/OpenSourceLicense/OpensourceLicenseViewReactor.swift
@@ -11,8 +11,8 @@ import ReactorKit
 
 class OpenSourceLicenseViewReactor: Reactor {
     enum Action {
-        /// Read opensource liscense notice text when view did load
-        case viewDidLoad
+        /// Read opensource liscense notice text
+        case load
     }
     
     enum Mutation {
@@ -36,8 +36,8 @@ class OpenSourceLicenseViewReactor: Reactor {
     // MARK: - mutation
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case .viewDidLoad:
-            return actionViewDidLoad()
+        case .load:
+            return actionLoad()
         }
     }
     
@@ -53,7 +53,7 @@ class OpenSourceLicenseViewReactor: Reactor {
     }
     
     // MARK: - action method
-    private func actionViewDidLoad() -> Observable<Mutation> {
+    private func actionLoad() -> Observable<Mutation> {
         /// Read opensource notice text file from bundle
         guard let path = Bundle.main.path(forResource: "OPENSOURCE", ofType: "html") else { return .empty() }
         let license = try? String(contentsOfFile: path, encoding: .utf8)

--- a/timer/Source/Module/TeamInfo/TeamInfoViewController.swift
+++ b/timer/Source/Module/TeamInfo/TeamInfoViewController.swift
@@ -51,37 +51,12 @@ class TeamInfoViewController: BaseHeaderViewController, View {
 	func bind(reactor: TeamInfoViewReactor) {
 		// MARK: action
         copyButton.rx.tap
-            .do(onNext: { [weak self] in self?.showEmailCopiedAlert() })
+            .do(onNext: { Toast(content: "toast_team_info_copy_email_title".localized).show(animated: true, withDuration: 3) })
             .subscribe(onNext: { [weak self] in UIPasteboard.general.string = self?.emailLabel.text })
             .disposed(by: disposeBag)
 
 		// MARK: state
 	}
-    
-    // MARK: - action method
-    /// Handle header button tap action according to button type
-    private func headerActionHandler(type: CommonHeader.ButtonType) {
-        switch type {
-        case .back:
-            navigationController?.popViewController(animated: true)
-
-        default:
-            break
-        }
-    }
-    
-    /// Show email copied alert view
-    private func showEmailCopiedAlert() {
-        let alert = AlertBuilder(message: "복사되었습니다").build()
-        // Alert view controller dismiss after 1 seconds
-        alert.rx.viewDidLoad
-            .delay(.seconds(1), scheduler: MainScheduler.instance)
-            .subscribe(onNext: { [weak alert] in alert?.dismiss(animated: true) })
-            .disposed(by: disposeBag)
-        
-        // Present alert view controller
-        present(alert, animated: true)
-    }
     
     deinit {
         Logger.verbose()

--- a/timer/Source/Module/TimeSetDetail/TimeSetDetailViewController.swift
+++ b/timer/Source/Module/TimeSetDetail/TimeSetDetailViewController.swift
@@ -92,11 +92,19 @@ class TimeSetDetailViewController: BaseHeaderViewController, View {
         
         // MARK: state
         // Bookmark
-        reactor.state
+        let isBookmark = reactor.state
             .map { $0.isBookmark }
             .distinctUntilChanged()
+            .share(replay: 1)
+        
+        isBookmark
             .filter { [weak self] _ in self?.headerView.buttons[.bookmark] != nil }
             .bind(to: headerView.buttons[.bookmark]!.rx.isSelected)
+            .disposed(by: disposeBag)
+        
+        isBookmark
+            .skipUntil(rx.viewDidAppear)
+            .subscribe(onNext: { Toast(content: $0 ? "toast_time_set_add_bookmark_title".localized : "toast_time_set_remove_bookmark_title".localized).show(animated: true, withDuration: 3) })
             .disposed(by: disposeBag)
         
         // Title
@@ -150,11 +158,19 @@ class TimeSetDetailViewController: BaseHeaderViewController, View {
             .bind(to: timerBadgeCollectionView.rx.items(dataSource: dataSource))
             .disposed(by: disposeBag)
         
-        reactor.state
+        let selectedIndex = reactor.state
             .map { $0.selectedIndex }
             .distinctUntilChanged()
+            .share(replay: 1)
+        
+        selectedIndex
             .map { IndexPath(item: $0, section: TimerBadgeSectionType.regular.rawValue) }
             .subscribe(onNext: { [weak self] in self?.timerBadgeCollectionView.scrollToBadge(at: $0, animated: true) })
+            .disposed(by: disposeBag)
+        
+        selectedIndex
+            .skipUntil(rx.viewDidAppear)
+            .subscribe(onNext: { _ in Toast(content: "toast_time_set_timer_selected_title".localized).show(animated: true, withDuration: 3) })
             .disposed(by: disposeBag)
     }
     

--- a/timer/Source/Module/TimeSetEdit/TimeSetEditViewController.swift
+++ b/timer/Source/Module/TimeSetEdit/TimeSetEditViewController.swift
@@ -129,6 +129,7 @@ class TimeSetEditViewController: BaseHeaderViewController, View {
     func bind(reactor: TimeSetEditViewReactor) {
         // DI
         timerOptionView.reactor = reactor.timerOptionViewReactor
+        bind(timerOption: timerOptionView)
         
         // MARK: action
         // Init badge
@@ -178,17 +179,6 @@ class TimeSetEditViewController: BaseHeaderViewController, View {
             .filter { $0.0.item == $0.1 }
             .map { [weak self] _ in !(self?.isTimerOptionVisible.value ?? true) }
             .bind(to: isTimerOptionVisible)
-            .disposed(by: disposeBag)
-        
-        timerOptionView.rx.tapApplyAll
-            .map { Reactor.Action.alarmApplyAll }
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
-        
-        timerOptionView.rx.tapDelete
-            .do(onNext: { [weak self] in self?.isTimerOptionVisible.accept(false) })
-            .map { Reactor.Action.deleteTimer }
-            .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
         cancelButton.rx.tap
@@ -300,6 +290,23 @@ class TimeSetEditViewController: BaseHeaderViewController, View {
             .filter { $0 }
             .subscribe(onNext: { [weak self] _ in _ = self?.coordinator.present(for: .home) })
             .disposed(by: disposeBag)
+    }
+    
+    private func bind(timerOption view: TimerOptionView) {
+        guard let reactor = reactor else { return }
+        
+        view.rx.tapApplyAll
+            .do(onNext: { Toast(content: String(format: "toast_alarm_all_apply_title".localized, $0.title)).show(animated: true, withDuration: 3) })
+            .map { Reactor.Action.alarmApplyAll($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        view.rx.tapDelete
+            .do(onNext: { [weak self] in self?.isTimerOptionVisible.accept(false) })
+            .map { Reactor.Action.deleteTimer }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
     }
     
     // MARK: - action method

--- a/timer/Source/Module/TimeSetEdit/TimeSetEditViewReactor.swift
+++ b/timer/Source/Module/TimeSetEdit/TimeSetEditViewReactor.swift
@@ -47,7 +47,7 @@ class TimeSetEditViewReactor: Reactor {
         case selectTimer(at: Int)
         
         /// Apply alarm to all timers
-        case alarmApplyAll
+        case alarmApplyAll(Alarm)
         
         /// Delete time set
         case deleteTimeSet
@@ -214,8 +214,8 @@ class TimeSetEditViewReactor: Reactor {
         case let .selectTimer(index):
             return actionSelectTimer(at: index)
             
-        case .alarmApplyAll:
-            return actionAlarmApplyAll()
+        case let .alarmApplyAll(alarm):
+            return actionAlarmApplyAll(alarm)
             
         case .deleteTimeSet:
             return actionDeleteTimeSet()
@@ -499,11 +499,9 @@ class TimeSetEditViewReactor: Reactor {
         return .concat(setEndTime, setTime, sectionReload, setSelectedIndex)
     }
     
-    private func actionAlarmApplyAll() -> Observable<Mutation> {
+    private func actionAlarmApplyAll(_ alarm: Alarm) -> Observable<Mutation> {
         // Update alarm of all timers to selected timer's alarm
-        let alarm = timeSetItem.timers[currentState.selectedIndex].alarm
         timeSetItem.timers.forEach { $0.alarm = alarm }
-        
         return .empty()
     }
     

--- a/timer/Source/Module/TimeSetProcess/TimeSetProcessViewReactor.swift
+++ b/timer/Source/Module/TimeSetProcess/TimeSetProcessViewReactor.swift
@@ -425,7 +425,7 @@ class TimeSetProcessViewReactor: Reactor {
     private func actionStopTimeSet() -> Observable<Mutation> {
         if countdownTimer.state != .end {
             // Dismiss
-            countdownTimer.end()
+            countdownTimer.stop()
         } else {
             // Cancel the time set
             timeSet.end()


### PR DESCRIPTION
# Change log
- Create `Toast`
- Apply toast to scenario
  - Timer alarm all apply
  - Bookmark
  - Select start timer
  - Team email copy
  - Induce time set memo when it ended
- Fix time set start issue when cancel during countdown
- Fix `dismissOrPopViewController(animated:)` to remove own view controller when pop view controller

# Description
## Toast
I create common `Toast`. it can represent 1 content, 1 task button. When you call `show(animated:duration:)`, It is shown on the window during `duration`.

### Using
```swift
/// Content only
Toast(content: "show only content").show(animated: true, withDuration: 3)

/// With task
Toast(content: "show content", 
         task: ToastTask(title: "task", handler: {
         // Do something when user touched task button
     })).show(animated: true, withDuration: 3)
```