### PR TITLE
PR: feature-timer-badge, Update timer badge collection view

### DIFF
--- a/timer/Source/Module/Common/TimerBadgeView/Cell/TimerBadgeCollectionViewCell.swift
+++ b/timer/Source/Module/Common/TimerBadgeView/Cell/TimerBadgeCollectionViewCell.swift
@@ -10,14 +10,14 @@ import UIKit
 import RxSwift
 import ReactorKit
 
-class TimerBadgeCollectionViewCell: UICollectionViewCell, View {
+class TimerBadgeCollectionViewCell: UICollectionViewCell, ReactorKit.View {
     // MARK: - view properties
     private let timerIconImageView: UIImageView = {
         let view = UIImageView(image: UIImage(named: "icon_timer"))
         return view
     }()
     
-    private let timerIndexLabel: UILabel = {
+    fileprivate let timerIndexLabel: UILabel = {
         let view = UILabel()
         view.font = Constants.Font.Bold.withSize(10.adjust())
         view.textColor = Constants.Color.silver
@@ -25,7 +25,7 @@ class TimerBadgeCollectionViewCell: UICollectionViewCell, View {
         return view
     }()
     
-    private let timeLabel: UILabel = {
+    fileprivate let timeLabel: UILabel = {
         let view = UILabel()
         view.setContentHuggingPriority(.required, for: .horizontal)
         view.setContentCompressionResistancePriority(.required, for: .horizontal)
@@ -187,3 +187,30 @@ class TimerBadgeCollectionViewCell: UICollectionViewCell, View {
         CATransaction.commit()
     }
 }
+
+#if canImport(SwiftUI) && DEBUG
+import SwiftUI
+
+struct TimerBadgeCollectionViewCellPreview: UIViewRepresentable {
+    func makeUIView(context: Context) -> TimerBadgeCollectionViewCell {
+        return TimerBadgeCollectionViewCell()
+    }
+    
+    func updateUIView(_ uiView: TimerBadgeCollectionViewCell, context: Context) {
+        uiView.timerIndexLabel.text = "1/1"
+        uiView.timeLabel.text = "00:00:00"
+        uiView.editButton.isHidden = false
+    }
+}
+
+struct Previews_TimerBadgeCollectionViewCellView: PreviewProvider {
+    static var previews: some SwiftUI.View {
+        Group {
+            TimerBadgeCollectionViewCellPreview()
+                .frame(width: 130, height: 70)
+                .previewLayout(.sizeThatFits)
+        }
+    }
+}
+
+#endif

--- a/timer/Source/Module/Common/TimerBadgeView/TimerBadgeCollectionView.swift
+++ b/timer/Source/Module/Common/TimerBadgeView/TimerBadgeCollectionView.swift
@@ -14,6 +14,30 @@ import JSReorderableCollectionView
 
 class TimerBadgeCollectionView: JSReorderableCollectionView {
     // MARK: - properties
+    let _dataSource = RxCollectionViewSectionedAnimatedDataSource<TimerBadgeSectionModel>(configureCell: { (dataSource, collectionView, indexPath, cellType) -> UICollectionViewCell in
+        switch cellType {
+        case let .regular(reactor):
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TimerBadgeCollectionViewCell.name, for: indexPath) as? TimerBadgeCollectionViewCell else { fatalError() }
+            cell.reactor = reactor
+            
+            return cell
+            
+        case let .extra(type):
+            switch type {
+            case .add:
+                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TimerBadgeAddCollectionViewCell.name, for: indexPath)
+                
+                return cell
+                
+            case let .repeat(reactor):
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TimerBadgeRepeatCollectionViewCell.name, for: indexPath) as? TimerBadgeRepeatCollectionViewCell else { fatalError() }
+                cell.reactor = reactor
+                
+                return cell
+            }
+        }
+    })
+    
     override var intrinsicContentSize: CGSize {
         return CGSize(width: 0, height: 90.adjust())
     }

--- a/timer/Source/Module/Common/TimerBadgeView/TimerBadgeCollectionView.swift
+++ b/timer/Source/Module/Common/TimerBadgeView/TimerBadgeCollectionView.swift
@@ -14,11 +14,14 @@ import JSReorderableCollectionView
 
 class TimerBadgeCollectionView: JSReorderableCollectionView {
     // MARK: - properties
-    let _dataSource = RxCollectionViewSectionedAnimatedDataSource<TimerBadgeSectionModel>(configureCell: { (dataSource, collectionView, indexPath, cellType) -> UICollectionViewCell in
+    var isEditable: Bool = false
+    
+    lazy var _dataSource = RxCollectionViewSectionedAnimatedDataSource<TimerBadgeSectionModel>(configureCell: { [weak self] dataSource, collectionView, indexPath, cellType -> UICollectionViewCell in
         switch cellType {
         case let .regular(reactor):
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TimerBadgeCollectionViewCell.name, for: indexPath) as? TimerBadgeCollectionViewCell else { fatalError() }
             cell.reactor = reactor
+            cell.editButton.isHidden = !(self?.isEditable ?? false)
             
             return cell
             

--- a/timer/Source/Module/HistoryList/HistoryDetail/HistoryDetailViewController.swift
+++ b/timer/Source/Module/HistoryList/HistoryDetail/HistoryDetailViewController.swift
@@ -39,19 +39,6 @@ class HistoryDetailViewController: BaseHeaderViewController, View {
     // MARK: - properties
     var coordinator: HistoryDetailViewCoordinator
     
-    private lazy var dataSource = RxCollectionViewSectionedAnimatedDataSource<TimerBadgeSectionModel>(configureCell: { (dataSource, collectionView, indexPath, cellType) -> UICollectionViewCell in
-        switch cellType {
-        case let .regular(reactor):
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TimerBadgeCollectionViewCell.name, for: indexPath) as? TimerBadgeCollectionViewCell else { fatalError() }
-            cell.reactor = reactor
-            
-            return cell
-            
-        case .extra(_):
-            fatalError("This view can't present extra cells of timer badge collection view")
-        }
-    })
-    
     // MARK: - constructor
     init(coordinator: HistoryDetailViewCoordinator) {
         self.coordinator = coordinator
@@ -197,7 +184,7 @@ class HistoryDetailViewController: BaseHeaderViewController, View {
         reactor.state
             .filter { $0.shouldSectionReload }
             .map { $0.sections }
-            .bind(to: timerBadgeCollectionView.rx.items(dataSource: dataSource))
+            .bind(to: timerBadgeCollectionView.rx.items(dataSource: timerBadgeCollectionView._dataSource))
             .disposed(by: disposeBag)
         
         let didTimeSetSaved = reactor.state

--- a/timer/Source/Module/Main/Productivity/ProductivityView.swift
+++ b/timer/Source/Module/Main/Productivity/ProductivityView.swift
@@ -80,6 +80,7 @@ class ProductivityView: UIView {
     
     let timerBadgeCollectionView: TimerBadgeCollectionView = {
         let view = TimerBadgeCollectionView(frame: .zero)
+        view.isEditable = true
         view.isAxisFixed = true
         if let layout = view.collectionViewLayout as? TimerBadgeCollectionViewFlowLayout {
             layout.axisPoint = TimerBadgeCollectionViewFlowLayout.Axis.center

--- a/timer/Source/Module/Main/Productivity/ProductivityViewController.swift
+++ b/timer/Source/Module/Main/Productivity/ProductivityViewController.swift
@@ -39,37 +39,6 @@ class ProductivityViewController: BaseHeaderViewController, View {
     private var footerView: Footer { return productivityView.footerView }
     
     // MARK: - properties
-    private lazy var dataSource = RxCollectionViewSectionedAnimatedDataSource<TimerBadgeSectionModel>(configureCell: { (dataSource, collectionView, indexPath, cellType) -> UICollectionViewCell in
-        switch cellType {
-        case let .regular(reactor):
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TimerBadgeCollectionViewCell.name, for: indexPath) as? TimerBadgeCollectionViewCell else { fatalError() }
-            cell.reactor = reactor
-            
-            return cell
-            
-        case let .extra(type):
-            switch type {
-            case .add:
-                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TimerBadgeAddCollectionViewCell.name, for: indexPath)
-                
-                return cell
-                
-            case let .repeat(reactor):
-                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TimerBadgeRepeatCollectionViewCell.name, for: indexPath) as? TimerBadgeRepeatCollectionViewCell else { fatalError() }
-                cell.reactor = reactor
-                
-                return cell
-            }
-        }
-    }, moveItem: { [weak self] dataSource, sourceIndexPath, destinationIndexPath in
-        let section = TimerBadgeSectionType.regular.rawValue
-        guard let reactor = self?.reactor,
-            sourceIndexPath.section == section && destinationIndexPath.section == section else { return }
-        
-        UIImpactFeedbackGenerator(style: .light).impactOccurred()
-        reactor.action.onNext(.moveTimer(at: sourceIndexPath.item, to: destinationIndexPath.item))
-    })
-    
     private let canTimeSetStart: BehaviorRelay<Bool> = BehaviorRelay(value: false)
     private let isTimerOptionVisible: BehaviorRelay<Bool> = BehaviorRelay(value: false)
     private var isBadgeMoving: Bool = false
@@ -96,6 +65,16 @@ class ProductivityViewController: BaseHeaderViewController, View {
         
         let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(longPressHandler(gesture:)))
         timerBadgeCollectionView.addGestureRecognizer(longPressGesture)
+        
+        // Set move item closure on timer badge datasource
+        timerBadgeCollectionView._dataSource.moveItem = { [weak self] dataSource, sourceIndexPath, destinationIndexPath in
+            let section = TimerBadgeSectionType.regular.rawValue
+            guard let reactor = self?.reactor,
+                sourceIndexPath.section == section && destinationIndexPath.section == section else { return }
+            
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            reactor.action.onNext(.moveTimer(at: sourceIndexPath.item, to: destinationIndexPath.item))
+        }
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -276,7 +255,7 @@ class ProductivityViewController: BaseHeaderViewController, View {
         reactor.state
             .filter { $0.shouldSectionReload }
             .map { $0.sections }
-            .bind(to: timerBadgeCollectionView.rx.items(dataSource: dataSource))
+            .bind(to: timerBadgeCollectionView.rx.items(dataSource: timerBadgeCollectionView._dataSource))
             .disposed(by: disposeBag)
         
         reactor.state
@@ -379,7 +358,7 @@ class ProductivityViewController: BaseHeaderViewController, View {
     }
     
     /// Convert badge select event to reactor action
-    private func selectBadge(at indexPath: IndexPath) -> Reactor.Action? {
+    private func selectBadge(at indexPath: IndexPath) -> TimeSetEditViewReactor.Action? {
         guard let reactor = reactor else { return nil }
         
         let cellType = reactor.currentState.sections[indexPath.section].items[indexPath.item]

--- a/timer/Source/Module/TimeSetDetail/TimeSetDetailViewController.swift
+++ b/timer/Source/Module/TimeSetDetail/TimeSetDetailViewController.swift
@@ -36,19 +36,6 @@ class TimeSetDetailViewController: BaseHeaderViewController, View {
     // MARK: - properties
     var coordinator: TimeSetDetailViewCoordinator
     
-    private lazy var dataSource = RxCollectionViewSectionedAnimatedDataSource<TimerBadgeSectionModel>(configureCell: { (dataSource, collectionView, indexPath, cellType) -> UICollectionViewCell in
-        switch cellType {
-        case let .regular(reactor):
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TimerBadgeCollectionViewCell.name, for: indexPath) as? TimerBadgeCollectionViewCell else { fatalError() }
-            cell.reactor = reactor
-            
-            return cell
-            
-        case .extra(_):
-            fatalError("This view can't present extra cells of timer badge collection view")
-        }
-    })
-    
     // MARK: - constructor
     init(coordinator: TimeSetDetailViewCoordinator) {
         self.coordinator = coordinator
@@ -155,7 +142,7 @@ class TimeSetDetailViewController: BaseHeaderViewController, View {
         reactor.state
             .filter { $0.shouldSectionReload }
             .map { $0.sections }
-            .bind(to: timerBadgeCollectionView.rx.items(dataSource: dataSource))
+            .bind(to: timerBadgeCollectionView.rx.items(dataSource: timerBadgeCollectionView._dataSource))
             .disposed(by: disposeBag)
         
         let selectedIndex = reactor.state

--- a/timer/Source/Module/TimeSetEdit/TimeSetEditView.swift
+++ b/timer/Source/Module/TimeSetEdit/TimeSetEditView.swift
@@ -80,6 +80,7 @@ class TimeSetEditView: UIView {
     
     let timerBadgeCollectionView: TimerBadgeCollectionView = {
         let view = TimerBadgeCollectionView(frame: .zero)
+        view.isEditable = true
         view.isAxisFixed = true
         if let layout = view.collectionViewLayout as? TimerBadgeCollectionViewFlowLayout {
             layout.axisPoint = TimerBadgeCollectionViewFlowLayout.Axis.center

--- a/timer/Source/Module/TimeSetProcess/TimeSetProcessViewController.swift
+++ b/timer/Source/Module/TimeSetProcess/TimeSetProcessViewController.swift
@@ -53,18 +53,6 @@ class TimeSetProcessViewController: BaseHeaderViewController, View {
     // MARK: - properties
     var coordinator: TimeSetProcessViewCoordinator
     
-    private lazy var dataSource = RxCollectionViewSectionedAnimatedDataSource<TimerBadgeSectionModel>(configureCell: { (dataSource, collectionView, indexPath, cellType) -> UICollectionViewCell in
-        switch cellType {
-        case let .regular(reactor):
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TimerBadgeCollectionViewCell.name, for: indexPath) as? TimerBadgeCollectionViewCell else { fatalError() }
-            cell.reactor = reactor
-            return cell
-            
-        case .extra(_):
-            fatalError("This view can't present extra cells of timer badge collection view")
-        }
-    })
-    
     // Dispose bags
     private var popupDisposeBag = DisposeBag()
     private var alertDisposeBag = DisposeBag()
@@ -254,7 +242,7 @@ class TimeSetProcessViewController: BaseHeaderViewController, View {
         reactor.state
             .filter { $0.shouldSectionReload }
             .map { $0.sections }
-            .bind(to: timerBadgeCollectionView.rx.items(dataSource: dataSource))
+            .bind(to: timerBadgeCollectionView.rx.items(dataSource: timerBadgeCollectionView._dataSource))
             .disposed(by: disposeBag)
         
         reactor.state

--- a/timer/Source/Module/TimeSetSave/TimeSetSaveViewController.swift
+++ b/timer/Source/Module/TimeSetSave/TimeSetSaveViewController.swift
@@ -34,19 +34,6 @@ class TimeSetSaveViewController: BaseHeaderViewController, View {
     // MARK: - properties
     var coordinator: TimeSetSaveViewCoordinator
     
-    private lazy var dataSource = RxCollectionViewSectionedAnimatedDataSource<TimerBadgeSectionModel>(configureCell: { (dataSource, collectionView, indexPath, cellType) -> UICollectionViewCell in
-        switch cellType {
-        case let .regular(reactor):
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TimerBadgeCollectionViewCell.name, for: indexPath) as? TimerBadgeCollectionViewCell else { fatalError() }
-            cell.reactor = reactor
-            
-            return cell
-            
-        case .extra(_):
-            fatalError("This view can't present extra cells of timer badge collection view")
-        }
-    })
-    
     // MARK: - constructor
     init(coordinator: TimeSetSaveViewCoordinator) {
         self.coordinator = coordinator
@@ -165,7 +152,7 @@ class TimeSetSaveViewController: BaseHeaderViewController, View {
         reactor.state
             .filter { $0.shouldSectionReload }
             .map { $0.sections }
-            .bind(to: timerBadgeCollectionView.rx.items(dataSource: dataSource))
+            .bind(to: timerBadgeCollectionView.rx.items(dataSource: timerBadgeCollectionView._dataSource))
             .disposed(by: disposeBag)
         
         reactor.state


### PR DESCRIPTION
# Change log
- Add hide option about edit button of timer badge collection view cell
- Move timer badge collection view datasource in collection view from each view controller

# Description
### Why `dataSource` move to `TimerBadgeCollectionView`?
Timer badge data source is same basically. but each view controller using `TimerBadgeCollectionView` has own data source. So i moved it to reduce unnecessary code repeat.

And then each view controller using `TimerBadgeCollectionView` write down this code to represent timer badges.
```swift
reactor.state
    .map { $0.sections } // Some origin data source
    .bind(to: timerBadgeCollectionView.rx.items(dataSource: timerBadgeCollectionView._dataSource)
    .disposed(by: disposeBag)
```