### PR TITLE
PR: feature-encoding-refactor, Fix about format & encoding

### DIFF
--- a/timer.xcodeproj/project.pbxproj
+++ b/timer.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		F33CFA2823675B7A00C4032A /* StopWatchItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F33CFA2723675B7A00C4032A /* StopWatchItem.swift */; };
 		F3457E502332850100B0EF97 /* OpensourceLicenseViewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3457E4F2332850100B0EF97 /* OpensourceLicenseViewReactor.swift */; };
 		F34CADE7236341EB007C2672 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F34CADE6236341EB007C2672 /* NotificationService.swift */; };
+		F35169832386863B00EFE74C /* String+encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = F35169822386863B00EFE74C /* String+encoding.swift */; };
 		F352034E227FCD0E00E05E2E /* CheckBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = F352034D227FCD0E00E05E2E /* CheckBox.swift */; };
 		F35203502280524300E05E2E /* UIViewController+rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = F352034F2280524300E05E2E /* UIViewController+rx.swift */; };
 		F3524F2C2343E1B50042ABF6 /* TimerBadgeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3524F2B2343E1B50042ABF6 /* TimerBadgeSection.swift */; };
@@ -278,6 +279,7 @@
 		F33CFA2723675B7A00C4032A /* StopWatchItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopWatchItem.swift; sourceTree = "<group>"; };
 		F3457E4F2332850100B0EF97 /* OpensourceLicenseViewReactor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpensourceLicenseViewReactor.swift; sourceTree = "<group>"; };
 		F34CADE6236341EB007C2672 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		F35169822386863B00EFE74C /* String+encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+encoding.swift"; sourceTree = "<group>"; };
 		F352034D227FCD0E00E05E2E /* CheckBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckBox.swift; sourceTree = "<group>"; };
 		F352034F2280524300E05E2E /* UIViewController+rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+rx.swift"; sourceTree = "<group>"; };
 		F3524F2B2343E1B50042ABF6 /* TimerBadgeSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerBadgeSection.swift; sourceTree = "<group>"; };
@@ -1021,6 +1023,7 @@
 				F3D1F7B6225CC357006DC162 /* Primitive+adjust.swift */,
 				F3D1F7B7225CC357006DC162 /* String+regex.swift */,
 				F3F800B5226A0D0F003D1D88 /* String+localized.swift */,
+				F35169822386863B00EFE74C /* String+encoding.swift */,
 				F3D1F7BA225CC357006DC162 /* UIColor+hex.swift */,
 				F3D1F7B9225CC357006DC162 /* UIView+autolayout.swift */,
 				F3790DDE238557850093D73E /* UIView+rx.swift */,
@@ -1555,6 +1558,7 @@
 				F3F21F7023338A100000597B /* NoticeDetailViewController.swift in Sources */,
 				F3CD184622F61776008DB221 /* FooterButton.swift in Sources */,
 				F3CD208322FD95E20059E1BA /* TimeSetEditViewCoordinator.swift in Sources */,
+				F35169832386863B00EFE74C /* String+encoding.swift in Sources */,
 				F3F54140232778D100D618D2 /* TimeSetManageView.swift in Sources */,
 				F3D1F7C4225CC3D7006DC162 /* Logger.swift in Sources */,
 				F3C187542262052300B2C644 /* TeamInfoView.swift in Sources */,

--- a/timer/Resource/en.lproj/Localizable.strings
+++ b/timer/Resource/en.lproj/Localizable.strings
@@ -112,11 +112,11 @@
 // MARK: - History
 "history_empty_title" = "You don't have any time set history yet. \nEnroll your own time!";
 "history_make_time_set_title" = "Create a time set";
-"history_started_date_format" = "YY.MM.dd";
+"history_started_date_format" = "yy.MM.dd";
 "history_date_title" = "Date";
 "history_extra_time_title" = "Extra";
 "history_repeat_count_title" = "Repetitions";
-"history_full_date_format" = "YY. M. d / h:m a";
+"history_full_date_format" = "yy. M. d / h:m a";
 "history_short_date_format" = "h:m a";
 "history_extra_time_format" = "+%dM";
 "history_repeat_count_format" = "%d";

--- a/timer/Resource/ko.lproj/Localizable.strings
+++ b/timer/Resource/ko.lproj/Localizable.strings
@@ -112,11 +112,11 @@
 // MARK: - History
 "history_empty_title" = "타임셋 히스토리가 아직 없어요.\n나만의 시간을 자유롭게 등록해 보세요!";
 "history_make_time_set_title" = "타임셋 만들어 보기";
-"history_started_date_format" = "YY.MM.dd";
+"history_started_date_format" = "yy.MM.dd";
 "history_date_title" = "사용 일시";
 "history_extra_time_title" = "추가한 시간";
 "history_repeat_count_title" = "반복 횟수";
-"history_full_date_format" = "YY. M. d / h:m a";
+"history_full_date_format" = "yy. M. d / h:m a";
 "history_short_date_format" = "h:m a";
 "history_extra_time_format" = "+%d분";
 "history_repeat_count_format" = "%d회";

--- a/timer/Source/Extension/String+encoding.swift
+++ b/timer/Source/Extension/String+encoding.swift
@@ -1,0 +1,13 @@
+//
+//  String+encoding.swift
+//  timer
+//
+//  Created by JSilver on 2019/11/21.
+//  Copyright © 2019 Jeong Jin Eun. All rights reserved.
+//
+
+import Foundation
+
+extension String.Encoding {
+    public static let euc_kr: String.Encoding = String.Encoding(rawValue: CFStringConvertEncodingToNSStringEncoding(0x0940))
+}

--- a/timer/Source/Module/Common/TimerOptionView/TimerOptionView.swift
+++ b/timer/Source/Module/Common/TimerOptionView/TimerOptionView.swift
@@ -354,7 +354,7 @@ class TimerOptionView: UIView, View {
         
         commentTextView.rx.text
             .orEmpty
-            .filter { $0.lengthOfBytes(using: .utf16) > Self.MAX_COMMENT_LENGTH }
+            .filter { $0.lengthOfBytes(using: .euc_kr) > Self.MAX_COMMENT_LENGTH }
             .do(onNext: { [weak self] _ in self?.isExceeded.accept(true) })
             .map { String($0.dropLast()) }
             .bind(to: commentTextView.rx.text)
@@ -364,7 +364,7 @@ class TimerOptionView: UIView, View {
         Observable.combineLatest(
             commentTextView.rx.text
                 .orEmpty
-                .map { $0.lengthOfBytes(using: .utf16) }
+                .map { $0.lengthOfBytes(using: .euc_kr) }
                 .distinctUntilChanged(),
             isExceeded.distinctUntilChanged())
             .compactMap { [weak self] in self?.getCommentLengthAttributedString(length: $0, isExceeded: $1) }

--- a/timer/Source/Module/HistoryList/HistoryDetail/HistoryDetailViewController.swift
+++ b/timer/Source/Module/HistoryList/HistoryDetail/HistoryDetailViewController.swift
@@ -73,7 +73,7 @@ class HistoryDetailViewController: BaseHeaderViewController, View {
         
         memoTextView.rx.text
             .orEmpty
-            .map { ($0, $0.lengthOfBytes(using: .utf16)) }
+            .map { ($0, $0.lengthOfBytes(using: .euc_kr)) }
             .filter { [weak self] in $0.1 > (self?.MAX_MEMO_LENGTH ?? 0) }
             .map { String($0.0.dropLast()) }
             .bind(to: memoTextView.rx.text)
@@ -153,7 +153,7 @@ class HistoryDetailViewController: BaseHeaderViewController, View {
         // Memo length
         let lengthOfBytes = reactor.state
             .map { $0.memo }
-            .map { $0.lengthOfBytes(using: .utf16) }
+            .map { $0.lengthOfBytes(using: .euc_kr) }
             .distinctUntilChanged()
             .share(replay: 1)
         

--- a/timer/Source/Module/TimeSetProcess/TimeSetEnd/TimeSetEndViewController.swift
+++ b/timer/Source/Module/TimeSetProcess/TimeSetEnd/TimeSetEndViewController.swift
@@ -60,7 +60,7 @@ class TimeSetEndViewController: BaseHeaderViewController, View {
         
         memoTextView.rx.text
             .orEmpty
-            .filter { $0.lengthOfBytes(using: .utf16) > Self.MAX_MEMO_LENGTH }
+            .filter { $0.lengthOfBytes(using: .euc_kr) > Self.MAX_MEMO_LENGTH }
             .do(onNext: { [weak self] _ in self?.isExceeded.accept(true) })
             .map { String($0.dropLast()) }
             .bind(to: memoTextView.rx.text)
@@ -70,7 +70,7 @@ class TimeSetEndViewController: BaseHeaderViewController, View {
         Observable.combineLatest(
             memoTextView.rx.text
                 .orEmpty
-                .map { $0.lengthOfBytes(using: .utf16) }
+                .map { $0.lengthOfBytes(using: .euc_kr) }
                 .distinctUntilChanged(),
             isExceeded.distinctUntilChanged())
             .compactMap { [weak self] in self?.getMemoLengthAttributedString(length: $0, isExceeded: $1) }

--- a/timer/Source/Module/TimeSetProcess/TimeSetMemo/TimeSetMemoViewController.swift
+++ b/timer/Source/Module/TimeSetProcess/TimeSetMemo/TimeSetMemoViewController.swift
@@ -58,7 +58,7 @@ class TimeSetMemoViewController: BaseHeaderViewController, View {
         
         memoTextView.rx.text
             .orEmpty
-            .filter { $0.lengthOfBytes(using: .utf16) > Self.MAX_MEMO_LENGTH }
+            .filter { $0.lengthOfBytes(using: .euc_kr) > Self.MAX_MEMO_LENGTH }
             .do(onNext: { [weak self] _ in self?.isExceeded.accept(true) })
             .map { String($0.dropLast()) }
             .bind(to: memoTextView.rx.text)
@@ -68,7 +68,7 @@ class TimeSetMemoViewController: BaseHeaderViewController, View {
         Observable.combineLatest(
             memoTextView.rx.text
                 .orEmpty
-                .map { $0.lengthOfBytes(using: .utf16) }
+                .map { $0.lengthOfBytes(using: .euc_kr) }
                 .distinctUntilChanged(),
             isExceeded.distinctUntilChanged())
             .compactMap { [weak self] in self?.getMemoLengthAttributedString(length: $0, isExceeded: $1) }

--- a/timer/Source/Module/TimeSetSave/TimeSetSaveView.swift
+++ b/timer/Source/Module/TimeSetSave/TimeSetSaveView.swift
@@ -7,13 +7,8 @@
 //
 
 import UIKit
-import RxSwift
-import RxCocoa
 
 class TimeSetSaveView: UIView {
-    // MARK: - constants
-    private let MAX_TITLE_LENGTH: Int = 20
-    
     // MARK: - view properties
     let headerView: CommonHeader = {
         let view = CommonHeader()
@@ -288,9 +283,6 @@ class TimeSetSaveView: UIView {
         return view
     }()
     
-    // MARK: - properties
-    private var disposeBag = DisposeBag()
-    
     // MARK: - constructor
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -319,35 +311,10 @@ class TimeSetSaveView: UIView {
             make.trailing.equalToSuperview()
             make.bottom.equalToSuperview()
         }
-        
-        bind()
     }
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    // MARK: - bind
-    private func bind() {
-        titleTextField.rx.textChanged
-            .compactMap { $0 }
-            .map { !$0.isEmpty }
-            .bind(to: titleHintLabel.rx.isHidden)
-            .disposed(by: disposeBag)
-        
-        titleTextField.rx.textChanged
-            .compactMap { $0 }
-            .map { $0.isEmpty }
-            .bind(to: titleClearButton.rx.isHidden)
-            .disposed(by: disposeBag)
-        
-        titleTextField.rx.text
-            .orEmpty
-            .map { ($0, $0.lengthOfBytes(using: .utf16)) }
-            .filter { [weak self] in $0.1 > (self?.MAX_TITLE_LENGTH ?? 0) }
-            .map { String($0.0.dropLast()) }
-            .bind(to: titleTextField.rx.text)
-            .disposed(by: disposeBag)
     }
     
     // MARK: - selector

--- a/timer/Source/Module/TimeSetSave/TimeSetSaveViewController.swift
+++ b/timer/Source/Module/TimeSetSave/TimeSetSaveViewController.swift
@@ -12,6 +12,9 @@ import ReactorKit
 import RxDataSources
 
 class TimeSetSaveViewController: BaseHeaderViewController, View {
+    // MARK: - constants
+    private let MAX_TITLE_LENGTH: Int = 20
+    
     // MARK: - view properties
     private var timeSetSaveView: TimeSetSaveView { return view as! TimeSetSaveView }
     
@@ -54,6 +57,30 @@ class TimeSetSaveViewController: BaseHeaderViewController, View {
     }
     
     // MARK: - bine
+    override func bind() {
+        super.bind()
+        
+        titleTextField.rx.textChanged
+            .compactMap { $0 }
+            .map { !$0.isEmpty }
+            .bind(to: titleHintLabel.rx.isHidden)
+            .disposed(by: disposeBag)
+        
+        titleTextField.rx.textChanged
+            .compactMap { $0 }
+            .map { $0.isEmpty }
+            .bind(to: titleClearButton.rx.isHidden)
+            .disposed(by: disposeBag)
+        
+        titleTextField.rx.text
+            .orEmpty
+            .map { ($0, $0.lengthOfBytes(using: .euc_kr)) }
+            .filter { [weak self] in $0.1 > (self?.MAX_TITLE_LENGTH ?? 0) }
+            .map { String($0.0.dropLast()) }
+            .bind(to: titleTextField.rx.text)
+            .disposed(by: disposeBag)
+    }
+    
     func bind(reactor: TimeSetSaveViewReactor) {
         // MARK: action
         rx.viewWillAppear


### PR DESCRIPTION
# Change log
- Change date format i was using "Y" to "y"
- Add encoding type of `EUC_KR` to calculate length of bytes of text input

# Description
### What is different between `UTF8` and `EUC_KR`
Previously i was using `UTF8` type of encoding. but actually designer requested me "1 byte for a english alphabet, 2 bytes for a korean alphabet".

In `UTF8` allocate 2 byte for both type of alphabets normally. It exactly not satisfied request. To satisfy it, i must use `EUC_KR` type of encoding.

But default swift's `String.Encoding` not serve `EUC_KR` type of encoding. thus i created extension and added it.
```swift
extension String.Encoding {
    public static let euc_kr: String.Encoding = String.Encoding(rawValue: CFStringConvertEncodingToNSStringEncoding(0x0940))
}
```

Convert `CFStringEncodings` (`CoreFoundation`) to `String.Encoding`. `0x0940` is `EUC_KR`'s raw value
```swift
public enum CFStringEncodings : CFIndex {
    ...
    // kCFStringEncodingEUC_KR = 0x0940 (objective-c)
    case EUC_KR
    ...
}

func CFStringConvertEncodingToNSStringEncoding(_ encoding: CFStringEncoding) -> UInt
```