### PR TITLE
PR: feature-did-saved-time-set, Update view to deal with time set can save state

### DIFF
--- a/timer/Source/Model/Data/RunningTimeSet.swift
+++ b/timer/Source/Model/Data/RunningTimeSet.swift
@@ -11,18 +11,21 @@ import Foundation
 struct RunningTimeSet: Codable {
     let timeSet: TimeSet
     let origin: TimeSetItem
+    let canSave: Bool
     
     enum CodingKeys: String, CodingKey {
         case item
         case history
         case origin
         case index
+        case canSave
     }
     
     // MARK: - constructor
-    init(timeSet: TimeSet, origin: TimeSetItem) {
+    init(timeSet: TimeSet, origin: TimeSetItem, canSave: Bool) {
         self.timeSet = timeSet
         self.origin = origin
+        self.canSave = canSave
     }
     
     init(from decoder: Decoder) throws {
@@ -33,6 +36,7 @@ struct RunningTimeSet: Codable {
         
         origin = try container.decode(TimeSetItem.self, forKey: .origin)
         timeSet = TimeSet(item: item, history: history, index: index)
+        canSave = try container.decode(Bool.self, forKey: .canSave)
     }
     
     // MARK: - codable
@@ -42,5 +46,6 @@ struct RunningTimeSet: Codable {
         try container.encode(timeSet.history, forKey: .history)
         try container.encode(origin, forKey: .origin)
         try container.encode(timeSet.currentIndex, forKey: .index)
+        try container.encode(canSave, forKey: .canSave)
     }
 }

--- a/timer/Source/Model/Data/TimeSetItem.swift
+++ b/timer/Source/Model/Data/TimeSetItem.swift
@@ -45,6 +45,7 @@ class TimeSetItem: Object, NSCopying, Codable {
         self.bookmarkSortingKey = bookmarkSortingKey
     }
     
+    // MARK: - decodable
     required convenience init(from decoder: Decoder) throws {
         self.init()
         
@@ -52,7 +53,11 @@ class TimeSetItem: Object, NSCopying, Codable {
         id = try? container.decode(String.self, forKey: .id)
         title = try container.decode(String.self, forKey: .title)
         isRepeat = try container.decode(Bool.self, forKey: .isRepeat)
+        isBookmark = (try? container.decode(Bool.self, forKey: .isBookmark)) ?? false
         timers = try container.decode([TimerItem].self, forKey: .timers).toList()
+        overtimer = try? container.decode(StopwatchItem.self, forKey: .overtimer)
+        sortingKey = (try? container.decode(Int.self, forKey: .sortingKey)) ?? Int.max
+        bookmarkSortingKey = (try? container.decode(Int.self, forKey: .bookmarkSortingKey)) ?? Int.max
     }
     
     // MARK: - realm method

--- a/timer/Source/Model/Data/TimerItem.swift
+++ b/timer/Source/Model/Data/TimerItem.swift
@@ -29,7 +29,9 @@ class TimerItem: Object, Codable, NSCopying, Recordable, Alertable {
     enum CodingKeys: String, CodingKey {
         case comment
         case alarm
+        case current
         case target = "end"
+        case extra
     }
     
     // MARK: - constructor
@@ -52,13 +54,16 @@ class TimerItem: Object, Codable, NSCopying, Recordable, Alertable {
         self.alarm = alarm
     }
     
+    // MARK: - decoable
     required convenience init(from decoder: Decoder) throws {
         self.init()
         
         let container = try decoder.container(keyedBy: CodingKeys.self)
         comment = try container.decode(String.self, forKey: .comment)
         alarm = try container.decode(Alarm.self, forKey: .alarm)
+        current = (try? container.decode(TimeInterval.self, forKey: .current)) ?? 0
         target = try container.decode(TimeInterval.self, forKey: .target)
+        extra = (try? container.decode(TimeInterval.self, forKey: .extra)) ?? 0
     }
     
     // MARK: - public method

--- a/timer/Source/Module/AllTimeSet/AllTimeSetViewCoordinator.swift
+++ b/timer/Source/Module/AllTimeSet/AllTimeSetViewCoordinator.swift
@@ -39,7 +39,7 @@ class AllTimeSetViewCoordinator: CoordinatorProtocol {
         switch route {
         case let .timeSetDetail(timeSetItem):
             let coordinator = TimeSetDetailViewCoordinator(provider: provider)
-            let reactor = TimeSetDetailViewReactor(timeSetService: provider.timeSetService, timeSetItem: timeSetItem)
+            let reactor = TimeSetDetailViewReactor(timeSetService: provider.timeSetService, timeSetItem: timeSetItem, canSave: false)
             let viewController = TimeSetDetailViewController(coordinator: coordinator)
             
             // DI

--- a/timer/Source/Module/Common/HeaderView/ConfirmHeader.swift
+++ b/timer/Source/Module/Common/HeaderView/ConfirmHeader.swift
@@ -20,14 +20,6 @@ class ConfirmHeader: Header {
         return view
     }()
     
-    let titleLabel: UILabel = {
-        let view = UILabel()
-        view.textAlignment = .center
-        view.font = Constants.Font.ExtraBold.withSize(18.adjust())
-        view.textColor = Constants.Color.codGray
-        return view
-    }()
-    
     let confirmButton: UIButton = {
         let view = UIButton()
         view.setTitle("header_button_confirm".localized, for: .normal)
@@ -35,12 +27,6 @@ class ConfirmHeader: Header {
         view.titleLabel?.font = Constants.Font.Regular.withSize(15.adjust())
         return view
     }()
-    
-    // MARK: - properties
-    override var title: String? {
-        set { titleLabel.text = newValue }
-        get { return titleLabel.text }
-    }
     
     // MARK: - properties
     override var intrinsicContentSize: CGSize {

--- a/timer/Source/Module/Common/HeaderView/Header.swift
+++ b/timer/Source/Module/Common/HeaderView/Header.swift
@@ -26,14 +26,26 @@ class Header: UIView {
         case close
     }
     
+    // MARK: - view properties
+    let titleLabel: UILabel = {
+        let view = UILabel()
+        view.font = Constants.Font.ExtraBold.withSize(18.adjust())
+        view.textColor = Constants.Color.codGray
+        return view
+    }()
+    
     // MARK: - properties
+    var title: String? {
+        set { titleLabel.text = newValue }
+        get { titleLabel.text }
+    }
+    
     var action: PublishRelay<Action> = PublishRelay()
     var disposeBag: DisposeBag = DisposeBag() {
         didSet { bind() }
     }
     
-    var title: String?
-    
+    // MARK: - constructor
     override init(frame: CGRect) {
         super.init(frame: frame)
         bind()
@@ -57,6 +69,6 @@ extension Reactive where Base: Header {
     
     /// The title of header view
     var title: Binder<String> {
-        return Binder(base) { _, title in self.base.title = title }
+        return Binder(base) { header, title in header.title = title }
     }
 }

--- a/timer/Source/Module/HistoryDetail/HistoryDetailViewController.swift
+++ b/timer/Source/Module/HistoryDetail/HistoryDetailViewController.swift
@@ -222,18 +222,20 @@ class HistoryDetailViewController: BaseHeaderViewController, View {
             .subscribe(onNext: { [weak self] in self?.showTimeSetEndStateAlert($0, index: $1, remainedTime: $2, overtime: $3) })
             .disposed(by: disposeBag)
         
-        let didTimeSetSaved = reactor.state
-            .map { $0.didTimeSetSaved }
+        // Time set can save
+        reactor.state
+            .map { $0.canTimeSetSave }
             .distinctUntilChanged()
-        
-        didTimeSetSaved
-            .map { !$0 }
             .bind(to: saveButton.rx.isEnabled)
             .disposed(by: disposeBag)
         
-        didTimeSetSaved
+        // Time set did saved
+        reactor.state
+            .map { $0.didTimeSetSaved }
+            .distinctUntilChanged()
+            .compactMap { $0.value }
             .filter { $0 }
-            .subscribe(onNext: { [weak self] in $0 ? self?.showTimeSetSavedToast() : nil })
+            .subscribe(onNext: { [weak self] _ in self?.showTimeSetSavedToast() })
             .disposed(by: disposeBag)
     }
     

--- a/timer/Source/Module/HistoryDetail/HistoryDetailViewCoordinator.swift
+++ b/timer/Source/Module/HistoryDetail/HistoryDetailViewCoordinator.swift
@@ -58,7 +58,7 @@ class HistoryDetailViewCoordinator: CoordinatorProtocol {
             
         case let .timeSetProcess(timeSetItem):
             let coordinator = TimeSetProcessViewCoordinator(provider: provider)
-            guard let reactor = TimeSetProcessViewReactor(appService: provider.appService, timeSetService: provider.timeSetService, timeSetItem: timeSetItem) else { return nil }
+            guard let reactor = TimeSetProcessViewReactor(appService: provider.appService, timeSetService: provider.timeSetService, timeSetItem: timeSetItem, canSave: true) else { return nil }
             let viewController = TimeSetProcessViewController(coordinator: coordinator)
             
             // DI

--- a/timer/Source/Module/HistoryDetail/HistoryDetailViewReactor.swift
+++ b/timer/Source/Module/HistoryDetail/HistoryDetailViewReactor.swift
@@ -74,8 +74,11 @@ class HistoryDetailViewReactor: Reactor {
         /// Need to reload section
         var shouldSectionReload: Bool
         
-        /// Time set saved
-        var didTimeSetSaved: Bool
+        /// Flag that represent current time set can save
+        var canTimeSetSave: Bool
+        
+        /// Flag that time set is saved
+        var didTimeSetSaved: RevisionValue<Bool?>
     }
     
     // MARK: - properties
@@ -102,23 +105,27 @@ class HistoryDetailViewReactor: Reactor {
         
         self.timeSetService = timeSetService
         self.history = history
-        initialState = State(title: item.title,
-                             runningTime: history.runningTime,
-                             startDate: startDate,
-                             endDate: endDate,
-                             extraTime: history.extraTime,
-                             repeatCount: history.repeatCount,
-                             memo: history.memo,
-                             endState: history.endState,
-                             endIndex: history.endIndex,
-                             remainedTime: item.timers.enumerated()
-                                .filter { $0.offset >= history.endIndex }
-                                .map { $0.element }
-                                .reduce(0) { $0 + ($1.end - $1.current) },
-                             overtime: item.overtimer?.current ?? 0,
-                             sectionDataSource: TimerBadgeDataSource(timers: item.timers.toArray()),
-                             shouldSectionReload: true,
-                             didTimeSetSaved: false)
+        
+        initialState = State(
+            title: item.title,
+            runningTime: history.runningTime,
+            startDate: startDate,
+            endDate: endDate,
+            extraTime: history.extraTime,
+            repeatCount: history.repeatCount,
+            memo: history.memo,
+            endState: history.endState,
+            endIndex: history.endIndex,
+            remainedTime: item.timers.enumerated()
+                .filter { $0.offset >= history.endIndex }
+                .map { $0.element }
+                .reduce(0) { $0 + ($1.end - $1.current) },
+            overtime: item.overtimer?.current ?? 0,
+            sectionDataSource: TimerBadgeDataSource(timers: item.timers.toArray()),
+            shouldSectionReload: true,
+            canTimeSetSave: true,
+            didTimeSetSaved: RevisionValue(nil)
+        )
     }
     
     // MARK: - mutation
@@ -146,7 +153,8 @@ class HistoryDetailViewReactor: Reactor {
             return state
             
         case .save:
-            state.didTimeSetSaved = true
+            state.canTimeSetSave = false
+            state.didTimeSetSaved = state.didTimeSetSaved.next(true)
             return state
         }
     }

--- a/timer/Source/Module/LocalTimeSet/LocalTimeSetViewCoordinator.swift
+++ b/timer/Source/Module/LocalTimeSet/LocalTimeSetViewCoordinator.swift
@@ -71,7 +71,7 @@ class LocalTimeSetViewCoordinator: CoordinatorProtocol {
             
         case let .timeSetDetail(timeSetItem):
             let coordinator = TimeSetDetailViewCoordinator(provider: provider)
-            let reactor = TimeSetDetailViewReactor(timeSetService: provider.timeSetService, timeSetItem: timeSetItem)
+            let reactor = TimeSetDetailViewReactor(timeSetService: provider.timeSetService, timeSetItem: timeSetItem, canSave: false)
             let viewController = TimeSetDetailViewController(coordinator: coordinator)
             
             // DI

--- a/timer/Source/Module/Main/MainViewCoordinator.swift
+++ b/timer/Source/Module/Main/MainViewCoordinator.swift
@@ -15,7 +15,6 @@ class MainViewCoordinator: CoordinatorProtocol {
         case productivity
         case local
         case preset
-        case timeSetProcess(TimeSetItem)
         case historyDetail(History)
     }
     
@@ -31,13 +30,6 @@ class MainViewCoordinator: CoordinatorProtocol {
         guard let viewController = get(for: route) else { return nil }
         
         switch route {
-        case .timeSetProcess:
-            guard let rootViewController = self.viewController.navigationController?.viewControllers.first else {
-                return nil
-            }
-            let viewControllers = [rootViewController, viewController]
-            self.viewController.navigationController?.setViewControllers(viewControllers, animated: true)
-            
         case .historyDetail(_):
             self.viewController.navigationController?.pushViewController(viewController, animated: true)
             
@@ -76,17 +68,6 @@ class MainViewCoordinator: CoordinatorProtocol {
             let coordinator = PresetViewCoordinator(provider: provider)
             let reactor = PresetViewReactor(networkService: provider.networkService)
             let viewController = PresetViewController(coordinator: coordinator)
-            
-            // DI
-            coordinator.viewController = viewController
-            viewController.reactor = reactor
-            
-            return viewController
-            
-        case let .timeSetProcess(timeSetItem):
-            let coordinator = TimeSetProcessViewCoordinator(provider: provider)
-            guard let reactor = TimeSetProcessViewReactor(appService: provider.appService, timeSetService: provider.timeSetService, timeSetItem: timeSetItem) else { return nil }
-            let viewController = TimeSetProcessViewController(coordinator: coordinator)
             
             // DI
             coordinator.viewController = viewController

--- a/timer/Source/Module/Preset/PresetViewCoordinator.swift
+++ b/timer/Source/Module/Preset/PresetViewCoordinator.swift
@@ -43,7 +43,7 @@ class PresetViewCoordinator: CoordinatorProtocol {
         switch route {
         case let .timeSetDetail(timeSetItem):
             let coordinator = TimeSetDetailViewCoordinator(provider: provider)
-            let reactor = TimeSetDetailViewReactor(timeSetService: provider.timeSetService, timeSetItem: timeSetItem)
+            let reactor = TimeSetDetailViewReactor(timeSetService: provider.timeSetService, timeSetItem: timeSetItem, canSave: true)
             let viewController = TimeSetDetailViewController(coordinator: coordinator)
             
             // DI

--- a/timer/Source/Module/Productivity/ProductivityViewCoordinator.swift
+++ b/timer/Source/Module/Productivity/ProductivityViewCoordinator.swift
@@ -56,7 +56,7 @@ class ProductivityViewCoordinator: CoordinatorProtocol {
             
         case let .timeSetProcess(timeSetItem):
             let coordinator = TimeSetProcessViewCoordinator(provider: provider)
-            guard let reactor = TimeSetProcessViewReactor(appService: provider.appService, timeSetService: provider.timeSetService, timeSetItem: timeSetItem) else { return nil }
+            guard let reactor = TimeSetProcessViewReactor(appService: provider.appService, timeSetService: provider.timeSetService, timeSetItem: timeSetItem, canSave: true) else { return nil }
             let viewController = TimeSetProcessViewController(coordinator: coordinator)
             
             // DI

--- a/timer/Source/Module/TimeSetDetail/TimeSetDetailView.swift
+++ b/timer/Source/Module/TimeSetDetail/TimeSetDetailView.swift
@@ -202,15 +202,13 @@ class TimeSetDetailView: UIView {
         return view
     }()
     
-    let editButton: FooterButton = {
-        return FooterButton(title: "footer_button_edit".localized, type: .sub)
-    }()
+    let saveButton: FooterButton = FooterButton(title: "footer_button_save".localized, type: .sub)
     
-    let startButton: FooterButton = {
-        return FooterButton(title: "footer_button_start".localized, type: .highlight)
-    }()
+    let editButton: FooterButton = FooterButton(title: "footer_button_edit".localized, type: .sub)
     
-    private lazy var footerView: Footer = {
+    let startButton: FooterButton = FooterButton(title: "footer_button_start".localized, type: .highlight)
+    
+    lazy var footerView: Footer = {
         let view = Footer()
         view.buttons = [editButton, startButton]
         return view

--- a/timer/Source/Module/TimeSetDetail/TimeSetDetailViewController.swift
+++ b/timer/Source/Module/TimeSetDetail/TimeSetDetailViewController.swift
@@ -74,7 +74,7 @@ class TimeSetDetailViewController: BaseHeaderViewController, View {
             .withLatestFrom(reactor.state
                 .map { $0.selectedIndex }
                 .distinctUntilChanged())
-            .subscribe(onNext: { [weak self] in _ = self?.coordinator.present(for: .timeSetProcess(reactor.timeSetItem, start: $0)) })
+            .subscribe(onNext: { [weak self] in _ = self?.coordinator.present(for: .timeSetProcess(reactor.timeSetItem, startAt: $0, canSave: false)) })
             .disposed(by: disposeBag)
         
         // MARK: state

--- a/timer/Source/Module/TimeSetDetail/TimeSetDetailViewCoordinator.swift
+++ b/timer/Source/Module/TimeSetDetail/TimeSetDetailViewCoordinator.swift
@@ -13,7 +13,7 @@ class TimeSetDetailViewCoordinator: CoordinatorProtocol {
     enum Route {
         case home
         case timeSetEdit(TimeSetItem)
-        case timeSetProcess(TimeSetItem, start: Int)
+        case timeSetProcess(TimeSetItem, startAt: Int, canSave: Bool)
     }
     
     // MARK: - properties
@@ -36,7 +36,7 @@ class TimeSetDetailViewCoordinator: CoordinatorProtocol {
         case .timeSetEdit(_):
             self.viewController.navigationController?.pushViewController(viewController, animated: true)
             
-        case .timeSetProcess(_, start: _):
+        case .timeSetProcess(_, startAt: _, canSave: _):
             guard let rootViewController = self.viewController.navigationController?.viewControllers.first else {
                 return nil
             }
@@ -63,9 +63,9 @@ class TimeSetDetailViewCoordinator: CoordinatorProtocol {
             
             return viewController
             
-        case let .timeSetProcess(timeSetItem, start: index):
+        case let .timeSetProcess(timeSetItem, startAt: index, canSave: canSave):
             let coordinator = TimeSetProcessViewCoordinator(provider: provider)
-            guard let reactor = TimeSetProcessViewReactor(appService: provider.appService, timeSetService: provider.timeSetService, timeSetItem: timeSetItem, startIndex: index) else { return nil }
+            guard let reactor = TimeSetProcessViewReactor(appService: provider.appService, timeSetService: provider.timeSetService, timeSetItem: timeSetItem, startIndex: index, canSave: canSave) else { return nil }
             let viewController = TimeSetProcessViewController(coordinator: coordinator)
             
             // DI

--- a/timer/Source/Module/TimeSetDetail/TimeSetDetailViewCoordinator.swift
+++ b/timer/Source/Module/TimeSetDetail/TimeSetDetailViewCoordinator.swift
@@ -65,7 +65,7 @@ class TimeSetDetailViewCoordinator: CoordinatorProtocol {
             
         case let .timeSetProcess(timeSetItem, start: index):
             let coordinator = TimeSetProcessViewCoordinator(provider: provider)
-            guard let reactor = TimeSetProcessViewReactor(appService: provider.appService, timeSetService: provider.timeSetService, timeSetItem: timeSetItem, start: index) else { return nil }
+            guard let reactor = TimeSetProcessViewReactor(appService: provider.appService, timeSetService: provider.timeSetService, timeSetItem: timeSetItem, startIndex: index) else { return nil }
             let viewController = TimeSetProcessViewController(coordinator: coordinator)
             
             // DI

--- a/timer/Source/Module/TimeSetEnd/TimeSetEndViewController.swift
+++ b/timer/Source/Module/TimeSetEnd/TimeSetEndViewController.swift
@@ -154,19 +154,20 @@ class TimeSetEndViewController: BaseHeaderViewController, View {
             .bind(to: memoTextView.rx.text)
             .disposed(by: disposeBag)
         
-        let didTimeSetSaved = reactor.state
-            .map { $0.didTimeSetSaved }
+        // Time set can save
+        reactor.state
+            .map { $0.canTimeSetSave }
             .distinctUntilChanged()
-        
-        didTimeSetSaved
-            .map { !$0 }
             .bind(to: saveButton.rx.isEnabled)
             .disposed(by: disposeBag)
         
-        didTimeSetSaved
-            .skip(1)
+        // Time set did save
+        reactor.state
+            .map { $0.didTimeSetSaved }
+            .distinctUntilChanged()
+            .compactMap { $0.value }
             .filter { $0 }
-            .subscribe(onNext: { [weak self] in $0 ? self?.showTimeSetSavedToast() : nil })
+            .subscribe(onNext: { [weak self] _ in self?.showTimeSetSavedToast() })
             .disposed(by: disposeBag)
     }
     

--- a/timer/Source/Module/TimeSetEnd/TimeSetEndViewReactor.swift
+++ b/timer/Source/Module/TimeSetEnd/TimeSetEndViewReactor.swift
@@ -42,8 +42,11 @@ class TimeSetEndViewReactor: Reactor {
         /// Memo of time set
         var memo: String
         
-        /// Time set saved
-        var didTimeSetSaved: Bool
+        /// Flag that represent current time set can save
+        var canTimeSetSave: Bool
+        
+        /// Flag that time set is saved
+        var didTimeSetSaved: RevisionValue<Bool?>
     }
     
     // MARK: - properties
@@ -65,15 +68,18 @@ class TimeSetEndViewReactor: Reactor {
     }
     
     // MARK: - constructor
-    init(timeSetService: TimeSetServiceProtocol, history: History) {
+    init(timeSetService: TimeSetServiceProtocol, history: History, canSave: Bool) {
         self.timeSetService = timeSetService
         self.history = history
         
-        initialState = State(title: history.item?.title ?? "",
-                             startDate: history.startDate ?? Date(),
-                             endDate: history.endDate ?? Date(),
-                             memo: history.memo,
-                             didTimeSetSaved: history.item?.id != nil)
+        initialState = State(
+            title: history.item?.title ?? "",
+            startDate: history.startDate ?? Date(),
+            endDate: history.endDate ?? Date(),
+            memo: history.memo,
+            canTimeSetSave: canSave,
+            didTimeSetSaved: RevisionValue(nil)
+        )
     }
     
     // MARK: - Mutate
@@ -100,7 +106,8 @@ class TimeSetEndViewReactor: Reactor {
             return state
             
         case .save:
-            state.didTimeSetSaved = true
+            state.canTimeSetSave = false
+            state.didTimeSetSaved = state.didTimeSetSaved.next(true)
             return state
         }
     }

--- a/timer/Source/Module/TimeSetProcess/TimeSetProcessViewCoordinator.swift
+++ b/timer/Source/Module/TimeSetProcess/TimeSetProcessViewCoordinator.swift
@@ -12,9 +12,9 @@ class TimeSetProcessViewCoordinator: CoordinatorProtocol {
     // MARK: - route enumeration
     enum Route {
         case home
-        case timeSetProcess(TimeSetItem)
+        case timeSetProcess(TimeSetItem, canSave: Bool)
         case timeSetMemo(History)
-        case timeSetEnd(History)
+        case timeSetEnd(History, canSave: Bool)
     }
     
     // MARK: - properties
@@ -62,9 +62,9 @@ class TimeSetProcessViewCoordinator: CoordinatorProtocol {
         case .home:
             return self.viewController.navigationController?.viewControllers.first
             
-        case let .timeSetProcess(timeSetItem):
+        case let .timeSetProcess(timeSetItem, canSave: canSave):
             let coordinator = TimeSetProcessViewCoordinator(provider: provider)
-            guard let reactor = TimeSetProcessViewReactor(appService: provider.appService, timeSetService: provider.timeSetService, timeSetItem: timeSetItem) else { return nil }
+            guard let reactor = TimeSetProcessViewReactor(appService: provider.appService, timeSetService: provider.timeSetService, timeSetItem: timeSetItem, canSave: canSave) else { return nil }
             let viewController = TimeSetProcessViewController(coordinator: coordinator)
             
             // DI
@@ -84,9 +84,9 @@ class TimeSetProcessViewCoordinator: CoordinatorProtocol {
             
             return viewController
             
-        case let .timeSetEnd(history):
+        case let .timeSetEnd(history, canSave: canSave):
             let coordinator = TimeSetEndViewCoordinator(provider: provider)
-            let reactor = TimeSetEndViewReactor(timeSetService: provider.timeSetService, history: history)
+            let reactor = TimeSetEndViewReactor(timeSetService: provider.timeSetService, history: history, canSave: canSave)
             let viewController = TimeSetEndViewController(coordinator: coordinator)
             
             // DI

--- a/timer/Source/Module/TimeSetProcess/TimeSetProcessViewReactor.swift
+++ b/timer/Source/Module/TimeSetProcess/TimeSetProcessViewReactor.swift
@@ -125,6 +125,9 @@ class TimeSetProcessViewReactor: Reactor {
         /// Flag that represent need to section reload
         var shouldSectionReload: Bool
         
+        /// Flag that represent current time set can save
+        let canTimeSetSave: Bool
+        
         /// Flag that view should dismiss
         var shouldDismiss: Bool
     }
@@ -142,7 +145,13 @@ class TimeSetProcessViewReactor: Reactor {
     private var countdownTimer: JSTimer
     
     // MARK: - constructor
-    private init(appService: AppServiceProtocol, timeSetService: TimeSetServiceProtocol, origin: TimeSetItem, timeSet: TimeSet) {
+    private init(
+        appService: AppServiceProtocol,
+        timeSetService: TimeSetServiceProtocol,
+        origin: TimeSetItem,
+        timeSet: TimeSet,
+        canSave: Bool
+    ) {
         self.appService = appService
         self.timeSetService = timeSetService
 
@@ -180,6 +189,7 @@ class TimeSetProcessViewReactor: Reactor {
             timer: timer,
             selectedIndex: index,
             shouldSectionReload: true,
+            canTimeSetSave: canSave,
             shouldDismiss: false
         )
     }
@@ -198,7 +208,8 @@ class TimeSetProcessViewReactor: Reactor {
             appService: appService,
             timeSetService: timeSetService,
             origin: runningTimeSet.origin,
-            timeSet: runningTimeSet.timeSet
+            timeSet: runningTimeSet.timeSet,
+            canSave: runningTimeSet.canSave
         )
         
         // End countdown timer
@@ -209,7 +220,8 @@ class TimeSetProcessViewReactor: Reactor {
         appService: AppServiceProtocol,
         timeSetService: TimeSetServiceProtocol,
         timeSetItem: TimeSetItem,
-        startIndex: Int = 0
+        startIndex: Int = 0,
+        canSave: Bool
     ) {
         guard startIndex >= 0 && startIndex < timeSetItem.timers.count else {
             Logger.error("can't start from \(startIndex) because time set not fulfill count of timers", tag: "TIME SET PROCESS")
@@ -223,7 +235,8 @@ class TimeSetProcessViewReactor: Reactor {
             appService: appService,
             timeSetService: timeSetService,
             origin: timeSetItem,
-            timeSet: TimeSet(item: copiedItem, index: startIndex)
+            timeSet: TimeSet(item: copiedItem, index: startIndex),
+            canSave: canSave
         )
     }
     
@@ -497,7 +510,11 @@ class TimeSetProcessViewReactor: Reactor {
             
             if timeSetService.runningTimeSet == nil {
                 // Set running time set only first time
-                timeSetService.runningTimeSet = RunningTimeSet(timeSet: timeSet, origin: origin)
+                timeSetService.runningTimeSet = RunningTimeSet(
+                    timeSet: timeSet,
+                    origin: origin,
+                    canSave: currentState.canTimeSetSave
+                )
             }
             
             return .concat(setTimeSetState, setExtraTime)

--- a/timer/Source/Module/TimeSetSave/TimeSetSaveViewCoordinator.swift
+++ b/timer/Source/Module/TimeSetSave/TimeSetSaveViewCoordinator.swift
@@ -43,7 +43,7 @@ class TimeSetSaveViewCoordinator: CoordinatorProtocol {
         switch route {
         case let .timeSetDetail(timeSetItem):
             let coordinator = TimeSetDetailViewCoordinator(provider: provider)
-            let reactor = TimeSetDetailViewReactor(timeSetService: provider.timeSetService, timeSetItem: timeSetItem)
+            let reactor = TimeSetDetailViewReactor(timeSetService: provider.timeSetService, timeSetItem: timeSetItem, canSave: false)
             let viewController = TimeSetDetailViewController(coordinator: coordinator)
             
             // DI


### PR DESCRIPTION
# Change log
- Update views that can save time set to receive time set can save state from outside.
  - `TimeSetEndViewReactor`
  - `TimeSetProcessViewReactor` (by-pass)
  - `TimeSetDetailViewReactor`
- Refactor `TimeSetProcessViewReactor` to separate constructor.
- Refactor `Header` and subclasses.
- Fix `TimeSetItem` & `TimerItem` model to decode about all properties in `init(from decoder:)`.

# Description
### What is changed about `canSave` state
In this sprint, I develop feature about `Preset`.

First problem is `TimeSetDetail` view should to branch layout that own time set can save. Because all time set detail use same module (`TimeSetDetail`) regardless it saved in device.

So i research previous views that already branch about save (`TimeSetEnd`). but it define `canSave` state by `TimeSetItem`'s `id` is `nil`. I thought that doesn't fulfill requirements to be changed.

Ex) In shared time set, other user shared time set has `id` but not saved yet in own device.

Now, views that should branch by `canSave` state should passed by parameter from outside.

Second, to distinguish saved toast and layout state, add `canTimeSetSave` and `didTimeSetSaved` properties.

`canTimeSetSave` is `Bool` type that represent view state and `didTimeSetSaved` is `RevisionValue<Bool?>` type that signal time set saved to view.

```swift
// Reactor
struct State {
    ...
    var canTimeSetSave: Bool
    var didTimeSetSaved: RevisionValue<Bool?>
    ...
}

// ViewController
func bind(reactor: Reactor) {
    ...
    reactor.state
        .map { $0.canTimeSetSave }
        .distinctUntilChanged()
        .subscribe(onNext: { [weak self] in self?.updateLayout(timeSet: $0) })
        .disposed(by: disposeBag)
    
    reactor.state
        .map { $0.didTimeSetSaved }
        .distinctUntilChanged()
        .compactMap { $0.value }
        .filter { $0 }
        .subscribe(onNext: { _ in Toast(content: "toast_time_set_saved_title".localized).show(animated: true, withDuration: 3) })
        .disposed(by: disposeBag)
    ...
}
```

### `Header` issue
In `TimeSetDetail`, during change layout about header's bookmark button, issue occurred that bookmark select state not changed. because create button every time when `headerView.buttons` changed.

So i change header view's buttons to manage reusable.
