### PR TITLE
PR: hotfix-time-set-manage, Fix issue that can't reorder saved time set

### DIFF
--- a/timer/Source/Module/TimeSetManage/TimeSetManageViewController.swift
+++ b/timer/Source/Module/TimeSetManage/TimeSetManageViewController.swift
@@ -245,6 +245,12 @@ extension TimeSetManageViewController: JSCollectionViewDelegateLayout {
 extension Reactive where Base: TimeSetManageViewController {
     var applied: ControlEvent<Void> {
         guard let reactor = base.reactor else { return ControlEvent(events: Observable.empty()) }
-        return ControlEvent(events: reactor.state.map { $0.applied }.distinctUntilChanged().map { _ in })
+        let source =  reactor.state
+            .map { $0.applied }
+            .distinctUntilChanged()
+            .filter { $0.value }
+            .map { _ in }
+        
+        return ControlEvent(events: source)
     }
 }

--- a/timer/Source/Module/TimeSetManage/TimeSetManageViewReactor.swift
+++ b/timer/Source/Module/TimeSetManage/TimeSetManageViewReactor.swift
@@ -134,11 +134,9 @@ class TimeSetManageViewReactor: Reactor {
     
     private func actionApply() -> Observable<Mutation> {
         let state = currentState
-        let sections = state.sections.value
-        guard sections.count == TimeSetManageSectionType.allCases.count else { return .empty() }
         
-        let updateTimeSets = sections[0].items.map { $0.timeSetItem }
-        let removeTimeSetIds = sections[1].items.compactMap { $0.timeSetItem.id }
+        let updateTimeSets = dataSource.savedTimeSetSection.map { $0.timeSetItem }
+        let removeTimeSetIds = dataSource.removedTimeSetSection.compactMap { $0.timeSetItem.id }
         
         // Set reordered sorting key
         updateTimeSets.enumerated().forEach {
@@ -175,8 +173,8 @@ typealias TimeSetManageCellType = TimeSetManageCollectionViewCellReactor
 
 struct TimeSetManageSectionDataSource {
     // MARK: - section
-    private var savedTimeSetSection: [TimeSetManageCellType] = []
-    private var removedTimeSetSection: [TimeSetManageCellType] = []
+    private(set) var savedTimeSetSection: [TimeSetManageCellType] = []
+    private(set) var removedTimeSetSection: [TimeSetManageCellType] = []
     
     // MARK: - public method
     mutating func setItems(_ items: [TimeSetItem], type: TimeSetManageViewReactor.TimeSetType) {


### PR DESCRIPTION
# Change log
- Fix issue that can't reorder saved time set
- Fix minor issue that apply event occur even if not applied of time set manage

# Description
I missed this issue while refactor section data source.

### AS-IS
```swift
private func actionMoveTimeSet(at sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) -> Observable<Mutation> {
    ....
    dataSource.swap(at: sourceIndexPath.item, to: destinationIndexPath.item, section: section)
    return .empty()
}

private func actionApply() -> Observable<Mutation> {
    ...
    let updateTimeSets = sections[0].items.map { $0.timeSetItem }
    let removeTimeSetIds = sections[1].items.compactMap { $0.timeSetItem.id }
    ...
}
```
If you move time set for reordering, action swap data without state change. So fixed to refer origin section data.

### TO-BE
```swift
private func actionApply() -> Observable<Mutation> {
    ...
    let updateTimeSets = dataSource.savedTimeSetSection.items.map { $0.timeSetItem }
    let removeTimeSetIds = dataSource.removedTimeSetSection.compactMap { $0.timeSetItem.id }
    ...
}
```