### PR TITLE
PR: featrue-local-time-set, Update history's origin id refer logic

### DIFF
--- a/timer/Resource/en.lproj/Localizable.strings
+++ b/timer/Resource/en.lproj/Localizable.strings
@@ -68,7 +68,6 @@
 "local_management_title" = "MANAGEMENT";
 "local_saved_time_set_section_title" = "SAVED TIMESET";
 "local_saved_time_set_all_show_title" = "SHOW ALL SAVED TIMESET";
-"local_frequently_used_time_set_section_title" = "FREQUENTLY USED TIMESET";
 "local_recently_used_time_set_section_title" = "RECENTLY USED TIMESET";
 "time_set_induce_title" = "Try add your timeset!";
 

--- a/timer/Resource/ko.lproj/Localizable.strings
+++ b/timer/Resource/ko.lproj/Localizable.strings
@@ -68,7 +68,6 @@
 "local_management_title" = "관리";
 "local_saved_time_set_section_title" = "저장한 타임셋";
 "local_saved_time_set_all_show_title" = "저장한 타임셋 모두보기";
-"local_frequently_used_time_set_section_title" = "자주 이용한 타임셋";
 "local_recently_used_time_set_section_title" = "최근 이용한 타임셋";
 "time_set_induce_title" = "타임셋을 추가해보세요!";
 

--- a/timer/Source/Model/Constant/Error.swift
+++ b/timer/Source/Model/Constant/Error.swift
@@ -7,6 +7,7 @@
 //
 
 enum DatabaseError: Error {
+    case invalidFormat
     case initialize
     case transaction
     case notFound

--- a/timer/Source/Model/Data/History.swift
+++ b/timer/Source/Model/Data/History.swift
@@ -46,7 +46,7 @@ import RealmSwift
     convenience init(item: TimeSetItem) {
         self.init()
         self.item = item
-        self.originId = item.isSaved ? item.id : -1
+        self.originId = item.isSaved ? -1 : item.id
     }
     
     private convenience init(

--- a/timer/Source/Model/Service/DatabaseServiceProtocol.swift
+++ b/timer/Source/Model/Service/DatabaseServiceProtocol.swift
@@ -26,13 +26,6 @@ protocol DatabaseServiceProtocol {
     /// - returns: A observable that emit n (count) recently used time set list
     func fetchRecentlyUsedTimeSets(count: Int) -> Single<[TimeSetItem]>
     
-    /// Fetch frequently used time set list
-    /// - parameters:
-    ///   - count: How many get results from the latest
-    ///   - date: Base date to get results
-    /// - returns: A observable that emit n (count) frequently used time set list
-    func fetchFrequentlyUsedTimeSets(count: Int, from date: Date) -> Single<[TimeSetItem]>
-    
     /// Create a time set
     /// - parameters:
     ///   - item: data of the time set

--- a/timer/Source/Model/Service/RealmService.swift
+++ b/timer/Source/Model/Service/RealmService.swift
@@ -97,7 +97,8 @@ class RealmService: BaseService, DatabaseServiceProtocol {
     }
     
     func createHistory(_ history: History) -> Single<History> {
-        create(history)
+        guard history.id > 0 && history.originId > 0 else { return .error(DatabaseError.invalidFormat) }
+        return create(history)
     }
     
     func updateHistory(_ history: History) -> Single<History> {

--- a/timer/Source/Model/Service/RealmService.swift
+++ b/timer/Source/Model/Service/RealmService.swift
@@ -37,33 +37,6 @@ class RealmService: BaseService, DatabaseServiceProtocol {
         }
     }
     
-    func fetchFrequentlyUsedTimeSets(count: Int, from date: Date) -> Single<[TimeSetItem]> {
-        // Fetch recent history list that refer saved time set and started after `date`
-        let recentUsedHistories: Single<[History]> = fetch(filter: NSPredicate(format: "originId > 0 AND startDate >= %@", date as NSDate))
-        
-        return recentUsedHistories.flatMap {
-            // Calculate using count of each time set
-            var usingCountDictionary: [Int: Int] = [:]
-            $0.map { $0.originId }
-                .forEach {
-                    if let count = usingCountDictionary[$0] {
-                        usingCountDictionary[$0] = count + 1
-                    } else {
-                        usingCountDictionary[$0] = 1
-                    }
-                }
-            
-            // Fetch time set item that used more than 3 times
-            return Single.zip(
-                usingCountDictionary.filter { $1 >= 3 }
-                    .sorted(by: { $0.value > $1.value })
-                    .range(0 ..< count)
-                    .map { $0.key }
-                    .map { id -> Single<TimeSetItem> in self.fetch(key: id) }
-            )
-        }
-    }
-    
     func createTimeSet(item: TimeSetItem) -> Single<TimeSetItem> {
         create(item)
     }

--- a/timer/Source/Model/Service/TimeSetService.swift
+++ b/timer/Source/Model/Service/TimeSetService.swift
@@ -39,9 +39,6 @@ protocol TimeSetServiceProtocol {
     /// Fetch recently used time set item list
     func fetchRecentlyUsedTimeSets(count: Int) -> Single<[TimeSetItem]>
     
-    /// Fetch frequently used time set item list
-    func fetchFrequentlyUsedTimeSets(count: Int, from date: Date) -> Single<[TimeSetItem]>
-    
     /// Create a time set
     func createTimeSet(item: TimeSetItem) -> Single<TimeSetItem>
     
@@ -135,11 +132,6 @@ class TimeSetService: BaseService, TimeSetServiceProtocol {
     
     func fetchRecentlyUsedTimeSets(count: Int) -> Single<[TimeSetItem]> {
         provider.databaseService.fetchRecentlyUsedTimeSets(count: count)
-            .do(onSuccess: { $0.forEach { $0.reset() } })
-    }
-    
-    func fetchFrequentlyUsedTimeSets(count: Int, from date: Date) -> Single<[TimeSetItem]> {
-        provider.databaseService.fetchFrequentlyUsedTimeSets(count: count, from: date)
             .do(onSuccess: { $0.forEach { $0.reset() } })
     }
     

--- a/timer/Source/Module/HistoryDetail/HistoryDetailViewReactor.swift
+++ b/timer/Source/Module/HistoryDetail/HistoryDetailViewReactor.swift
@@ -184,26 +184,16 @@ class HistoryDetailViewReactor: Reactor {
     private func actionSaveTimeSet() -> Observable<Mutation> {
         // Create the time set
         timeSetService.createTimeSet(item: timeSetItem)
-            .do(onSuccess: {
-                self.history.originId = $0.id
-                self.timeSetItem = $0
-            })
-            .flatMap { _ in self.timeSetService.updateHistory(self.history) }
             .asObservable()
             .map { _ in .save }
     }
     
     private func actionStartTimeSet() -> Observable<Mutation> {
-        if history.originId < 0 {
-            // Non-saved time set
-            return .just(.start)
-        } else {
-            // Saved time set
-            return timeSetService.fetchTimeSet(id: history.originId)
-                .do(onSuccess: { self.timeSetItem = $0 })
-                .asObservable()
-                .map { _ in .start }
-        }
+        // Fetch origin time set item from local database
+        timeSetService.fetchTimeSet(id: history.originId)
+            .do(onSuccess: { self.timeSetItem = $0 })
+            .asObservable()
+            .map { _ in .start }
     }
     
     deinit {

--- a/timer/Source/Module/LocalTimeSet/LocalTimeSetViewController.swift
+++ b/timer/Source/Module/LocalTimeSet/LocalTimeSetViewController.swift
@@ -45,8 +45,7 @@ class LocalTimeSetViewController: BaseHeaderViewController, ViewControllable, Vi
                     return cell
                 }
                 
-            case .frequentlyUsed,
-                 .recentlyUsed:
+            case .recentlyUsed:
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SavedTimeSetSmallCollectionViewCell.name, for: indexPath) as? SavedTimeSetSmallCollectionViewCell else { fatalError("Can't dequeue reusable cell type of `SavedTimeSetSmallCollectionViewCell`.") }
                 cell.reactor = reactor
                 return cell
@@ -109,10 +108,6 @@ class LocalTimeSetViewController: BaseHeaderViewController, ViewControllable, Vi
                         self?.bind(manage: viewController)
                     })
                     .disposed(by: supplementaryView.disposeBag)
-                
-            case .frequentlyUsed:
-                // Frequently used time set
-                supplementaryView.title = "local_frequently_used_time_set_section_title".localized
                 
             case .recentlyUsed:
                 // Recently used time set

--- a/timer/Source/Module/LocalTimeSet/LocalTimeSetViewCoordinator.swift
+++ b/timer/Source/Module/LocalTimeSet/LocalTimeSetViewCoordinator.swift
@@ -15,7 +15,7 @@ class LocalTimeSetViewCoordinator: ViewCoordinator, ServiceContainer {
         case productivity
         case timeSetManage
         case allTimeSet
-        case timeSetDetail(TimeSetItem)
+        case timeSetDetail(TimeSetItem, canSave: Bool)
         case history
         case setting
     }
@@ -72,8 +72,8 @@ class LocalTimeSetViewCoordinator: ViewCoordinator, ServiceContainer {
             let dependency = AllTimeSetViewBuilder.Dependency(provider: provider)
             return AllTimeSetViewBuilder(with: dependency).build()
             
-        case let .timeSetDetail(timeSetItem):
-            let dependency = TimeSetDetailViewBuilder.Dependency(provider: provider, timeSetItem: timeSetItem, canSave: false)
+        case let .timeSetDetail(timeSetItem, canSave: canSave):
+            let dependency = TimeSetDetailViewBuilder.Dependency(provider: provider, timeSetItem: timeSetItem, canSave: canSave)
             return TimeSetDetailViewBuilder(with: dependency).build()
 
         case .history:

--- a/timer/Source/Module/LocalTimeSet/LocalTimeSetViewReactor.swift
+++ b/timer/Source/Module/LocalTimeSet/LocalTimeSetViewReactor.swift
@@ -77,15 +77,10 @@ class LocalTimeSetViewReactor: Reactor {
     
     // MARK: - action method
     private func actionRefresh() -> Observable<Mutation> {
-        guard let date = Calendar.current.date(byAdding: .day, value: -7, to: Date()) else { return .empty() }
-        
-        return Single.zip(
+        Single.zip(
             timeSetService.fetchTimeSets()
                 .catchErrorJustReturn([])
                 .do(onSuccess: { self.dataSource.setItems($0) }),
-            timeSetService.fetchFrequentlyUsedTimeSets(count: 3, from: date)
-                .catchErrorJustReturn([])
-                .do(onSuccess: { self.dataSource.setFrequentlyUsed(timeSets: $0) }),
             timeSetService.fetchRecentlyUsedTimeSets(count: 3)
                 .catchErrorJustReturn([])
                 .do(onSuccess: { self.dataSource.setRecentlyUsed(timeSets: $0) })
@@ -109,7 +104,6 @@ typealias LocalTimeSetSectionModel = SectionModel<LocalTimeSetSectionType, Local
 
 enum LocalTimeSetSectionType {
     case saved
-    case frequentlyUsed
     case recentlyUsed
 }
 
@@ -132,7 +126,6 @@ enum LocalTimeSetCellType {
 struct LocalTimeSetDataSource {
     // MARK: - section
     private var savedTimeSetSection: [LocalTimeSetCellType] = []
-    private var frequentlyUsedTimeSetSection: [LocalTimeSetCellType] = []
     private var recentlyUsedTimeSetSection: [LocalTimeSetCellType] = []
     
     // MARK: - property
@@ -160,11 +153,6 @@ struct LocalTimeSetDataSource {
         
     }
     
-    mutating func setFrequentlyUsed(timeSets: [TimeSetItem]) {
-        // Make section data
-        frequentlyUsedTimeSetSection = timeSets.map { .regular(TimeSetCollectionViewCellReactor(timeSetItem: $0)) }
-    }
-    
     mutating func setRecentlyUsed(timeSets: [TimeSetItem]) {
         // Make section data
         recentlyUsedTimeSetSection = timeSets.map { .regular(TimeSetCollectionViewCellReactor(timeSetItem: $0)) }
@@ -177,16 +165,11 @@ struct LocalTimeSetDataSource {
             items: self.savedTimeSetSection
         )
         
-        let frequentlyUsedTimeSetSection = LocalTimeSetSectionModel(
-            model: .frequentlyUsed,
-            items: self.frequentlyUsedTimeSetSection
-        )
-        
         let recentlyUsedTimeSetSection = LocalTimeSetSectionModel(
             model: .recentlyUsed,
             items: self.recentlyUsedTimeSetSection
         )
         
-        return [savedTimeSetSection, frequentlyUsedTimeSetSection, recentlyUsedTimeSetSection].filter { $0.items.count > 0 }
+        return [savedTimeSetSection, recentlyUsedTimeSetSection].filter { $0.items.count > 0 }
     }
 }


### PR DESCRIPTION
# Change log
- Update local time set coordinator for present to time set detail when recently used time set section selected.
- Update history's origin id refer logic to separate time set started from saved time set.
- Remove frequently used time set section in local time set tab

# Description
Due to plan changes, updated local time set tab.
