### PR TITLE
PR: feature-fix-time-set-detail, Fix time set detail view controller bind

### DIFF
--- a/timer/Source/Module/TimeSetDetail/TimeSetDetailViewController.swift
+++ b/timer/Source/Module/TimeSetDetail/TimeSetDetailViewController.swift
@@ -124,7 +124,7 @@ class TimeSetDetailViewController: BaseHeaderViewController, ViewControllable, V
         let timer = reactor.state
             .map { $0.timer }
             .distinctUntilChanged()
-            .share()
+            .share(replay: 1)
         
         // Alarm
         timer.map { $0.alarm.title }


### PR DESCRIPTION
# Change log
- Fix `TimeSetDetailViewController`'s `timer` bind to `share(replay: 1)`.

# Description
### `share(replay: 1)` is required?
The state that mapped to `timer` emit value when subscribe due to `Reactor.State` replay one.
If you subscribe(bind) like `alarmLabel.rx.text`, mapped state are emit and consume value by first subscription immediately. Thus next subscription like `commentTextView.rx.text` share same stream, but can't receive value in subscribe timing.

So I add `share(replay: 1)` to share first value between shared streams.